### PR TITLE
Fixed compression format not displaying correctly in run page

### DIFF
--- a/src/js/components/api.js
+++ b/src/js/components/api.js
@@ -97,7 +97,7 @@ export const Run = Backbone.Model.extend({
  * @return {string} url
  */
 export function getKronaURL(runId, pipelineVersion, ssuOrLsu) {
-    return API_URL + 'runs/' + runId + '/pipelines/' + pipelineVersion + '/krona'+ssuOrLsu;
+    return API_URL + 'runs/' + runId + '/pipelines/' + pipelineVersion + '/krona' + ssuOrLsu;
 }
 
 export const RunsCollection = Backbone.Collection.extend({
@@ -353,6 +353,9 @@ function clusterRunDownloads(downloads) {
             const groupFormat = d.attributes['file-format']['name'];
             if (groupLabel === label && groupFormat === format) {
                 d.attributes.links = d.attributes.links.concat(download.links.self);
+                if (attr['file-format']['compression']) {
+                    d.attributes['file-format']['compExtension'] = attr.alias.split('.').slice(-1);
+                }
                 grouped = true;
             }
         });

--- a/src/run.html
+++ b/src/run.html
@@ -247,7 +247,7 @@
         <% _.each(groups, function(group, name){ %>
         <h3> <%= name %></h3>
         <div class="row columns">
-            <table>
+            <table class="runs-download-table">
                 <thead>
                 <tr>
                     <th>Name</th>
@@ -260,7 +260,7 @@
                 <% _.each(group, function(entry){ %>
                 <tr>
                     <td><%= entry.attributes.description.label %></td>
-                    <td><%= entry.attributes['file-format'].compression ? entry.attributes['file-format'].extension :
+                    <td><%= entry.attributes['file-format'].compression ? entry.attributes['file-format'].compExtension :
                         '-' %>
                     </td>
                     <td><%= entry.attributes['file-format'].name %></td>

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -36,6 +36,23 @@
     width: 10em;
 }
 
+.runs-download-table {
+    table-layout: fixed;
+    text-align: center;
+}
+
+.runs-download-table th:first-child {
+    width: 20em;
+}
+
+.runs-download-table th:nth-child(2) {
+    width: 8em;
+}
+
+.runs-download-table th:nth-child(3) {
+    width: 5em;
+}
+
 td, th {
     word-wrap: break-word;
 }


### PR DESCRIPTION
Fixed compression being displayed as TSV instead of GZ (for example). Also added css changes to improve table format.