### PR TITLE
changing links from FTP to HTTP

### DIFF
--- a/src/js/modules/browse.js
+++ b/src/js/modules/browse.js
@@ -300,7 +300,7 @@ let GenomeCataloguesView = util.GenericTableView.extend({
                 'metagenomic-assembled and isolate genomes. ' +
                 'The latest version of each catalogue is shown on this website. ' +
                 'Data for current and previous versions are available on the ' +
-                '[FTP server](ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/).' +
+                '[FTP server](https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/).' +
                 '\n\n' +
                 'Select a catalogue in the table to browse or search its genomes.'
             ),

--- a/src/partials/pipelines/5.handlebars
+++ b/src/partials/pipelines/5.handlebars
@@ -232,7 +232,7 @@
             </tr>
             <tr>
                 <td>
-                    <a class="ext" href="ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/kegg_dbs/">KOfam - a modified version based on KEGG 90.0</a>
+                    <a class="ext" href="https://ftp.ebi.ac.uk/pub/databases/metagenomics/kegg_dbs/">KOfam - a modified version based on KEGG 90.0</a>
                 </td>
                 <td><em>2019-04-06</em></td>
                 <td>KEGG Ortholog prediction</td>

--- a/src/pipelines.html
+++ b/src/pipelines.html
@@ -33,7 +33,7 @@
 
             <ul>
                 <li>
-                    Major upgrade. This version offers specialised workflows for three different data types: amplicon, raw metagenomic/metatranscriptomic reads, and assembly. Each workflow is defined in common workflow language (CWL) and available in the <a class="ext" href="https://github.com/EBI-Metagenomics/pipeline-v5" alt="CWL MGnify github repository">MGnify v5.0 CWL repository</a>. All databases are available from an <a class="ext" href="ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/pipeline-5.0/ref-dbs" alt="FTP URL">FTP link</a>.
+                    Major upgrade. This version offers specialised workflows for three different data types: amplicon, raw metagenomic/metatranscriptomic reads, and assembly. Each workflow is defined in common workflow language (CWL) and available in the <a class="ext" href="https://github.com/EBI-Metagenomics/pipeline-v5" alt="CWL MGnify github repository">MGnify v5.0 CWL repository</a>. All databases are available from an <a class="ext" href="https://ftp.ebi.ac.uk/pub/databases/metagenomics/pipeline-5.0/ref-dbs" alt="FTP URL">FTP link</a>.
                 </li>
             </ul>
 


### PR DESCRIPTION
Changing links from using the ftp protocol to use http because browsers are not supporting FTP anymore.
e.g. https://blog.mozilla.org/security/2021/07/20/stopping-ftp-support-in-firefox-90/

Please @mberacochea have a look and if OK please merge and deploy.