### PR TITLE
Patch the Runs webpage for runs with no link to a study.

### DIFF
--- a/src/hooks/data/useData/index.tsx
+++ b/src/hooks/data/useData/index.tsx
@@ -48,6 +48,9 @@ export type MGnifyDatum = {
     sample?: {
       data: RelationshipDatum;
     };
+    analyses?: {
+      data: RelationshipDatum;
+    };
     assemblies?: {
       data: Array<KeyValue>;
     };

--- a/src/pages/Run/index.tsx
+++ b/src/pages/Run/index.tsx
@@ -24,11 +24,22 @@ const RunPage: React.FC = () => {
   const details = [
     {
       key: 'Study',
-      value: () => (
-        <Link to={`/studies/${runData.relationships.study.data.id}`}>
-          {runData.relationships.study.data.id}
-        </Link>
-      ),
+      value: () => {
+        if (!runData.relationships.study.data) {
+          return (
+            <ExtLink
+              href={`${ENA_VIEW_URL}${runData.attributes['ena-study-accession']}`}
+            >
+              {runData.attributes['ena-study-accession']}
+            </ExtLink>
+          );
+        }
+        return (
+          <Link to={`/studies/${runData.relationships.study.data.id}`}>
+            {runData.relationships.study.data.id}
+          </Link>
+        );
+      },
     },
     {
       key: 'Sample',
@@ -65,9 +76,11 @@ const RunPage: React.FC = () => {
           <Box label="Description">
             <KeyValueList list={details} />
           </Box>
-          <Box label="Associated analyses">
-            <AssociatedAnalyses rootEndpoint="runs" />
-          </Box>
+          {runData.relationships.analyses.data && (
+            <Box label="Associated analyses">
+              <AssociatedAnalyses rootEndpoint="runs" />
+            </Box>
+          )}
           <Box label="Associated assemblies">
             <AssociatedAssemblies rootEndpoint="runs" />
           </Box>


### PR DESCRIPTION
Those Runs have the property ena-study-accession field populated
with the Study accession.