### PR TITLE
Redirect to canonical accessions

### DIFF
--- a/src/hooks/useCanonicalAccessionRedirect/index.tsx
+++ b/src/hooks/useCanonicalAccessionRedirect/index.tsx
@@ -1,0 +1,25 @@
+import useURLAccession from 'hooks/useURLAccession';
+import { MGnifyResponseObj } from 'hooks/data/useData';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const useCanonicalAccessionRedirect = (data: MGnifyResponseObj) => {
+  const urlAccession = useURLAccession();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { pathname } = location;
+
+  if (!data) return;
+  if (!urlAccession) return;
+
+  const dataAccession = data.data.id;
+
+  if (
+    dataAccession &&
+    dataAccession.toUpperCase() !== urlAccession.toUpperCase()
+  ) {
+    navigate(pathname.replace(urlAccession, dataAccession));
+  }
+};
+
+export default useCanonicalAccessionRedirect;

--- a/src/pages/Study/index.tsx
+++ b/src/pages/Study/index.tsx
@@ -9,6 +9,7 @@ import Tabs from 'components/UI/Tabs';
 import Overview from 'components/Study/Overview';
 import SummaryTab from 'components/Study/SummaryTab';
 import RouteForHash from 'components/Nav/RouteForHash';
+import useCanonicalAccessionRedirect from 'hooks/useCanonicalAccessionRedirect';
 
 const tabs = [
   { label: 'Overview', to: '#overview' },
@@ -20,6 +21,7 @@ const StudyPage: React.FC = () => {
   const { data, loading, error } = useMGnifyData(`studies/${accession}`, {
     include: 'publications',
   });
+  useCanonicalAccessionRedirect(data as MGnifyResponseObj);
   if (loading) return <Loading size="large" />;
   if (error) return <FetchError error={error} />;
   if (!data) return <Loading />;


### PR DESCRIPTION
This PR:
- adds a hook that conditionally redirects to the canonical (primary) accession for objects
- applies this to the Study detail page

## Background
Some objects (like Studies) have multiple accessions, e.g. a PRJ or ERP prefixed accession as well as the MGnify-assigned MGYS. The EMG API allows either the primary or secondary accessions to be used as pseudo-primary-keys.
E.g. `api/v1/studies/MGYS1` and `api/v1/studies/ERP1` might both return the same object.
For now, we are keeping this, even though it is quite non-RESTy. In a future API version, we may wish to either change these to 30x redirects (which would break user's scripts if implemented now), or encourage the use of an endpoint filter like `api/v1/studies?accession_search=ERP1`. For now, we just want to redirect website users to the canonical (MGYS) accession even if they follow a URL with an ENA accessioned Study. 