### PR TITLE
Feature/amr crispr genome annos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           pip install --user --upgrade pip setuptools
           python -V
           pip -V
-          pip install "git+https://github.com/EBI-metagenomics/emgapi@switch-to-pyproject#egg=emgcli"
+          pip install "git+https://github.com/EBI-metagenomics/emgapi@develop#egg=emgcli"
           ls -l
 
       - name: Set up db files for API

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           pip install --user --upgrade pip setuptools
           python -V
           pip -V
-          pip install "git+https://github.com/EBI-metagenomics/emgapi@develop#egg=emgcli"
+          pip install "git+https://github.com/EBI-metagenomics/emgapi@switch-to-pyproject#egg=emgcli"
           ls -l
 
       - name: Set up db files for API

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 
 #### How to setup your project?
 
+**MGnify-web**
+It is usually preferable to use the [mgnify-web parent repo](https://github.com/EBI-Metagenomics/mgnify-web) for development.
+The parent repo lets you work on the API and this client side-by-side.
+
+To work on the web client alone, you can connect to one of the remote MGnify APIs:
 Export the following env variables in env-config.sh file. 
 Adjust exports if need depending on whether you are in your dev or
 prod environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dexie-react-hooks": "1.1.1",
         "highcharts": "9.3.2",
         "highcharts-react-official": "3.1.0",
-        "igv": "^2.15.3",
+        "igv": "^2.15.8",
         "jszip": "^3.10.1",
         "lodash-es": "4.17.21",
         "mgnify-sourmash-component": "0.2.4",
@@ -8650,9 +8650,9 @@
       }
     },
     "node_modules/igv": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/igv/-/igv-2.15.4.tgz",
-      "integrity": "sha512-EZzE7qLPsjq7nXQ2Rn2+Vp8266RAVvZSzSwRZFmy7as3ybwDlHOVZnSwZglEOv2F9nIe8i8dxroDIuTIK4HuCQ=="
+      "version": "2.15.8",
+      "resolved": "https://registry.npmjs.org/igv/-/igv-2.15.8.tgz",
+      "integrity": "sha512-E5T78a0v979k7l8t5izNN7ZGXH4lbg8XnRBLuubFGt6TeclSWNCSjQZuemujpO9prMP8edcWz7oIXCeS1kEEWw=="
     },
     "node_modules/immediate": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dexie-react-hooks": "1.1.1",
     "highcharts": "9.3.2",
     "highcharts-react-official": "3.1.0",
-    "igv": "^2.15.3",
+    "igv": "^2.15.8",
     "jszip": "^3.10.1",
     "lodash-es": "4.17.21",
     "mgnify-sourmash-component": "0.2.4",

--- a/src/components/Analysis/ContigViewer/index.tsx
+++ b/src/components/Analysis/ContigViewer/index.tsx
@@ -38,6 +38,7 @@ import useQueryParamState from 'hooks/queryParamState/useQueryParamState';
 import {
   AnnotationTrackColorPicker,
   annotationTrackCustomisations,
+  FORMAT,
 } from 'components/IGV/TrackColourPicker';
 import AnalysisContext from 'pages/Analysis/AnalysisContext';
 import JSZip from 'jszip';
@@ -228,7 +229,7 @@ const Contig: React.FC<ContigProps> = ({ contig }) => {
         if (colorBy) {
           const newTrackConfig = {
             ...trackView.track.config,
-            ...annotationTrackCustomisations(colorBy.value),
+            ...annotationTrackCustomisations(colorBy.value, FORMAT.ASSEMBLY_V5),
           };
           if (newTrackConfig.nameField !== trackView.track.config.nameField) {
             // Prevent unnecessary track reloads

--- a/src/components/Analysis/ContigViewer/mgnifyColours.tsx
+++ b/src/components/Analysis/ContigViewer/mgnifyColours.tsx
@@ -66,3 +66,34 @@ export function getMiBIGColor(mibigClass) {
 
 export const COLOUR_PRESENCE = '#d32f2f';
 export const COLOUR_ABSENCE = '#a9abaa';
+
+const CRISPR_MAP = {
+  CRISPR: COLOUR_PRESENCE,
+  CRISPRdr: '#ffb81c',
+  CRISPRspacer: '#734595',
+  LeftFLANK: '#e58f9e',
+  RightFLANK: '#e58f9e',
+};
+
+export function getCRISPRColour(featureType) {
+  return CRISPR_MAP[featureType] || COLOUR_ABSENCE;
+}
+
+const FEATURE_TYPE_MAP = {
+  CRISPR: CRISPR_MAP.CRISPRdr,
+  CDS: '#18974c',
+  ncRNA: '#6cc24a',
+  CLUSTER: '#3b6fb6',
+  prophage: '#d41645',
+  viral_sequence: '#d41645',
+  plasmid: '#734595',
+  integron: '#734595',
+  attC_site: '#734595',
+  insertion_sequence: '#734595',
+  terminal_inverted_repeat_element: '#734595',
+  conjugative_transposon: '#734595',
+};
+
+export function getFeatureTypeColour(featureType) {
+  return FEATURE_TYPE_MAP[featureType] || COLOUR_ABSENCE;
+}

--- a/src/components/Genomes/Browser/Popup/index.tsx
+++ b/src/components/Genomes/Browser/Popup/index.tsx
@@ -303,12 +303,49 @@ const formatData = (
     ],
   };
 
+  const amrData = {
+    title: 'Anti-microbial resistance',
+    data: [
+      {
+        name: 'AMRFinderPlus gene symbol',
+        Value: attributes.amrfinderplus_gene_symbol,
+      },
+      {
+        name: 'AMRFinderPlus sequence name',
+        Value: attributes.amrfinderplus_sequence_name,
+      },
+      {
+        name: 'AMRFinderPlus scope',
+        Value: attributes.amrfinderplus_scope,
+      },
+      {
+        name: 'Element type',
+        Value: attributes.element_type,
+      },
+      {
+        name: 'Element subtype',
+        Value: attributes.element_subtype,
+      },
+      {
+        name: 'Drug class',
+        Value: attributes.drug_class,
+      },
+      {
+        name: 'Drug subclass',
+        Value: attributes.drug_subclass,
+      },
+    ],
+  };
+
   const properties = [functionalData, otherData];
   if (withMetaProteomics && attributes.pride_id) {
     properties.push(metaproteomicData);
   }
   if (attributes.nearest_mibig) {
     properties.push(bgcData);
+  }
+  if (attributes.amrfinderplus_gene_symbol) {
+    properties.push(amrData);
   }
 
   return {

--- a/src/components/Genomes/Browser/Popup/index.tsx
+++ b/src/components/Genomes/Browser/Popup/index.tsx
@@ -337,7 +337,31 @@ const formatData = (
     ],
   };
 
+  const crisprData = {
+    title: 'CRISPR details',
+    data: [
+      {
+        name: 'sequence',
+        Value: attributes.sequence || attributes.dr,
+      },
+    ],
+  };
+  if (attributes.type === 'CRISPR') {
+    crisprData.data.push(
+      {
+        name: 'CRISPRCasFinder evidence level',
+        Value: attributes.evidence_level,
+      },
+      { name: 'Potential direction', Value: attributes.potential_direction },
+      { name: 'Number of spacers', Value: attributes.number_of_spacers },
+      { name: 'Direct repeat length', Value: attributes.dr_length }
+    );
+  }
+
   const properties = [functionalData, otherData];
+  if (attributes.source.toLowerCase().includes('crispr')) {
+    properties.push(crisprData);
+  }
   if (withMetaProteomics && attributes.pride_id) {
     properties.push(metaproteomicData);
   }
@@ -349,7 +373,7 @@ const formatData = (
   }
 
   return {
-    name: attributes.id,
+    name: attributes.id || attributes.name,
     gene: attributes.gene,
     product: attributes.product,
     properties,

--- a/src/components/Genomes/Browser/index.tsx
+++ b/src/components/Genomes/Browser/index.tsx
@@ -14,6 +14,7 @@ import Loading from 'components/UI/Loading';
 import {
   AnnotationTrackColorPicker,
   annotationTrackCustomisations,
+  FORMAT,
 } from 'components/IGV/TrackColourPicker';
 import GenomeBrowserPopup from './Popup';
 
@@ -47,9 +48,11 @@ const GenomeBrowser: React.FC = () => {
             name: 'Functional annotation',
             type: 'annotation',
             format: 'gff3',
+            height: 120,
             url: `${config.api}genomes/${accession}/downloads/${accession}.gff`,
             displayMode: 'EXPANDED',
             label: 'Functional annotation',
+            searchable: true,
           },
         ],
         showLegend: true,
@@ -62,9 +65,11 @@ const GenomeBrowser: React.FC = () => {
             name: 'Viral annotation',
             type: 'annotation',
             format: 'gff3',
+            height: 120,
             url: virifyGffUrl,
             displayMode: 'EXPANDED',
             label: 'Viral annotation',
+            searchable: true,
           });
         }
       });
@@ -93,7 +98,7 @@ const GenomeBrowser: React.FC = () => {
       if (colorBy) {
         const newTrackConfig = {
           ...trackView.track.config,
-          ...annotationTrackCustomisations(colorBy.value),
+          ...annotationTrackCustomisations(colorBy.value, FORMAT.GENOME),
         };
         if (newTrackConfig.nameField !== trackView.track.config.nameField) {
           // Prevent unnecessary track reloads

--- a/src/components/IGV/TrackColourPicker/index.tsx
+++ b/src/components/IGV/TrackColourPicker/index.tsx
@@ -5,11 +5,15 @@ import {
   COLOUR_PRESENCE,
   getAntiSMASHColour,
   getCOGColour,
+  getCRISPRColour,
+  getFeatureTypeColour,
   getMiBIGColor,
 } from 'components/Analysis/ContigViewer/mgnifyColours';
 import ExtLink from 'components/UI/ExtLink';
 import Tooltip from 'components/UI/Tooltip';
 import ROCratePreview from 'components/IGV/ROCrateTrack';
+import { useEffectOnce } from 'react-use';
+import { find } from 'lodash-es';
 
 function maybeGetAttributeValue(feature, attrPossibleNames: string[]) {
   if (!feature || !feature.getAttributeValue) return null;
@@ -23,11 +27,16 @@ function maybeGetAttributeValue(feature, attrPossibleNames: string[]) {
   return null;
 }
 
-export const annotationTrackCustomisations = (trackColorBy) => {
+export const FORMAT = {
+  GENOME: 'GENOME',
+  ASSEMBLY_V5: 'ASSEMBLY_V5',
+};
+
+export const annotationTrackCustomisations = (trackColorBy, format) => {
   switch (trackColorBy) {
     case 'cog':
       return {
-        nameField: 'COG',
+        nameField: format === FORMAT.GENOME ? 'COG' : 'cog',
         color: (feature) => {
           const cog = maybeGetAttributeValue(feature, ['cog', 'COG']);
           return cog ? getCOGColour(cog) : '#ddd';
@@ -35,7 +44,7 @@ export const annotationTrackCustomisations = (trackColorBy) => {
       };
     case 'kegg':
       return {
-        nameField: 'kegg',
+        nameField: format === FORMAT.GENOME ? 'KEGG' : 'kegg',
         color: (feature) =>
           !maybeGetAttributeValue(feature, ['kegg', 'KEGG'])
             ? COLOUR_ABSENCE
@@ -43,7 +52,7 @@ export const annotationTrackCustomisations = (trackColorBy) => {
       };
     case 'pfam':
       return {
-        nameField: 'pfam',
+        nameField: format === FORMAT.GENOME ? 'Pfam' : 'pfam',
         color: (feature) =>
           !maybeGetAttributeValue(feature, ['pfam', 'Pfam'])
             ? COLOUR_ABSENCE
@@ -51,7 +60,7 @@ export const annotationTrackCustomisations = (trackColorBy) => {
       };
     case 'interpro':
       return {
-        nameField: 'interpro',
+        nameField: format === FORMAT.GENOME ? 'InterPro' : 'interpro',
         color: (feature) =>
           !maybeGetAttributeValue(feature, ['interpro', 'InterPro'])
             ? COLOUR_ABSENCE
@@ -59,7 +68,7 @@ export const annotationTrackCustomisations = (trackColorBy) => {
       };
     case 'go':
       return {
-        nameField: 'go',
+        nameField: format === FORMAT.GENOME ? 'GO' : 'go',
         color: (feature) =>
           !maybeGetAttributeValue(feature, ['go', 'GO'])
             ? COLOUR_ABSENCE
@@ -94,6 +103,26 @@ export const annotationTrackCustomisations = (trackColorBy) => {
           return mibigClass ? getMiBIGColor(mibigClass) : '#ddd';
         },
       };
+    case 'amr':
+      return {
+        nameField: 'AMRFinderPlus_gene_symbol',
+        color: (feature) =>
+          !maybeGetAttributeValue(feature, [
+            'amrfinderplus_gene_symbol',
+            'AMRFinderPlus_gene_symbol',
+          ])
+            ? COLOUR_ABSENCE
+            : COLOUR_PRESENCE,
+      };
+    case 'crispr':
+      return {
+        color: (feature) => getCRISPRColour(feature.type),
+      };
+    case 'type':
+      return {
+        nameField: 'ID',
+        color: (feature) => getFeatureTypeColour(feature.type),
+      };
     default:
       return {
         nameField: trackColorBy,
@@ -109,30 +138,59 @@ const trackColorOptionsForType = (track) => {
   const trackType = track.id;
   const { crate } = track.config;
   if (crate) {
-    return crate.tree.variableMeasured.map((vm) => ({
+    const options = crate.tree.variableMeasured.map((vm) => ({
       label: vm.name[0]['@value'],
       value: vm.value[0]['@value'],
     }));
+    if (options.length) {
+      return { options, default: options[0].value };
+    }
+    return { options };
   }
   switch (trackType) {
     case 'SanntiS annotation':
-      return [{ label: 'MiBIG class', value: 'mibig' }];
+      return {
+        options: [{ label: 'MiBIG class', value: 'mibig' }],
+        default: 'mibig',
+      };
     case 'Viral annotation':
-      return [{ label: 'ViPhOG existence', value: 'viphog' }];
+      return {
+        options: [{ label: 'ViPhOG existence', value: 'viphog' }],
+        default: 'viphog',
+      };
     case 'antiSMASH':
-      return [{ label: 'AntiSMASH cluster type', value: 'antismash' }];
+      return {
+        options: [{ label: 'AntiSMASH cluster type', value: 'antismash' }],
+        default: 'antismash',
+      };
     case 'Functional annotation':
     default:
-      return [
-        { label: 'AntiSMASH cluster type', value: 'antismash' },
-        { label: 'COG category', value: 'cog' },
-        { label: 'GO (gene ontology) existence', value: 'go' },
-        { label: 'InterPro existence', value: 'interpro' },
-        { label: 'KEGG ortholog', value: 'kegg' },
-        { label: 'MiBIG class', value: 'mibig' },
-        { label: 'Pfam family existence', value: 'pfam' },
-        { label: 'ViPhOG existence', value: 'viphog' },
-      ];
+      return {
+        options: [
+          { label: 'Feature type', value: 'type' },
+          {
+            label: 'Protein function annotations',
+            options: [
+              { label: 'COG category', value: 'cog' },
+              { label: 'GO (gene ontology) existence', value: 'go' },
+              { label: 'InterPro existence', value: 'interpro' },
+              { label: 'KEGG ortholog', value: 'kegg' },
+              { label: 'Pfam family existence', value: 'pfam' },
+              { label: 'AMR existence', value: 'amr' },
+            ],
+          },
+          {
+            label: 'Other features',
+            options: [
+              { label: 'AntiSMASH cluster type', value: 'antismash' },
+              { label: 'MiBIG class', value: 'mibig' },
+              { label: 'ViPhOG existence', value: 'viphog' },
+              { label: 'CRISPR component', value: 'crispr' },
+            ],
+          },
+        ],
+        default: 'type',
+      };
   }
 };
 
@@ -145,6 +203,18 @@ type AnnotationTrackColorPickerProps = {
 export const AnnotationTrackColorPicker: React.FC<
   AnnotationTrackColorPickerProps
 > = ({ trackView, trackColorBys, onChange }) => {
+  const { options, default: defaultValue } = trackColorOptionsForType(
+    trackView.track
+  );
+  const existingSelection = trackColorBys[trackView.track.id];
+  useEffectOnce(() => {
+    if (!existingSelection) {
+      //   First mount of selector widget and no config already set.
+      //   Set to predefined default.
+      const defaultOption = find(options, (o) => o.value === defaultValue);
+      onChange(defaultOption, { action: 'select-option' });
+    }
+  });
   return (
     <div className="vf-stack vf-stack--200">
       <label
@@ -164,7 +234,7 @@ export const AnnotationTrackColorPicker: React.FC<
         onChange={onChange}
         name={`track-colour-${trackView.track.id}`}
         inputId={`track-colour-${trackView.track.id}`}
-        options={trackColorOptionsForType(trackView.track)}
+        options={options}
       />
       {trackView.track.id === 'SanntiS annotation' && (
         <span className="vf-text-body vf-text-body--4">


### PR DESCRIPTION
This PR:
- adds support for AMRFinderPlus and CRISPRCasFinder annotations on IGV
  - currently used for genome GFFs, not assembly annos.
- adds a default IGV track colouring for genome and assembly contig browsing, that represents the different feature types
  - useful now that more and more features are represented in a single GFF, e.g. clusters, CDS, ncRNA etc
- upgrades IGV.js version to fix some bugs
- fixes various bugs with the IGV track configs stemming from different naming conventions in genome vs. assembly gffs