### PR TITLE
Adds "jump to accession" button to hero search header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgportalv2",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgportalv2",
-      "version": "2.0.17",
+      "version": "2.0.18",
       "license": "ISC",
       "dependencies": {
         "@googlemaps/markerclustererplus": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mgportalv2",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Web Client for the Mgnify service at EBI",
   "homepage": "https://github.com/EBI-Metagenomics/ebi-metagenomics-client#readme",
   "main": "src/index.tsx",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import './App.css';
 import './styles/biomes.css';
 import 'react-toastify/dist/ReactToastify.css';
 import './styles/toast.css';
+import './styles/search.css';
 import { ToastContainer } from 'react-toastify';
 import QueryParamsProvider from 'hooks/queryParamState/QueryParamStore/QueryParamContext';
 import Matomo from 'components/Analytics';

--- a/src/components/UI/HeroHeader/index.tsx
+++ b/src/components/UI/HeroHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import './style.css';
 
@@ -6,11 +6,14 @@ import MGnifyLogo from 'images/mgnify_logo_reverse.svg';
 import useQueryParamsStore from 'hooks/queryParamState/QueryParamStore/useQueryParamsStore';
 import { createParamFromURL } from 'hooks/queryParamState/QueryParamStore/queryParamReducer';
 import Link from 'components/UI/Link';
+import { getDetailOrSearchURLForQuery } from 'utils/accessions';
 
 const HeroHeader: React.FC = () => {
   const searchBox = useRef<HTMLInputElement>();
   const location = useLocation();
   const navigate = useNavigate();
+  const [isAccessionLike, setIsAccessionLike] = useState(false);
+  const [nextURL, setNextURL] = useState('/search/studies');
   const { dispatch } = useQueryParamsStore();
   const setSearchQuery = (query: string) => {
     dispatch(
@@ -20,6 +23,21 @@ const HeroHeader: React.FC = () => {
       })
     );
   };
+
+  const handleInput = () => {
+    if (!searchBox.current) return;
+    const accessionMatcherResults = getDetailOrSearchURLForQuery(
+      searchBox.current.value.trim()
+    );
+    setNextURL(accessionMatcherResults.nextURL);
+    setIsAccessionLike(accessionMatcherResults.isAccessionLike);
+  };
+
+  useEffect(() => {
+    // ensures jump/search button state resets when using back button
+    handleInput();
+  }, [location]);
+
   return (
     <section className="vf-hero vf-hero--400 | vf-u-fullbleed">
       <div className="vf-hero__content | vf-box | vf-stack vf-stack--400">
@@ -45,8 +63,10 @@ const HeroHeader: React.FC = () => {
             onSubmit={async (e) => {
               e.preventDefault();
               const searchText = searchBox.current.value;
-              setSearchQuery(searchText);
-              await navigate('/search/studies');
+              if (!isAccessionLike) {
+                setSearchQuery(searchText);
+              }
+              navigate(nextURL);
               searchBox.current.value = '';
               searchBox.current.blur();
             }}
@@ -61,20 +81,43 @@ const HeroHeader: React.FC = () => {
                 </label>
                 <input
                   type="search"
+                  onChange={handleInput}
                   placeholder="Search MGnify"
                   ref={searchBox}
                   className="vf-form__input"
                 />
               </div>
+              <div className="search-buttons-container">
+                <button
+                  type={isAccessionLike ? 'submit' : 'button'}
+                  className={`vf-search__button | vf-button vf-button--primary slide-in-button ${
+                    isAccessionLike ? 'slide-in-shown' : 'slide-in-hidden'
+                  }`}
+                >
+                  <span className="vf-button__text | vf-u-sr-only">Go</span>
 
-              <button
-                type="submit"
-                className="vf-search__button | vf-button vf-button--primary"
-              >
-                <span className="vf-button__text | vf-u-sr-only">Search</span>
+                  <span className="icon icon-common icon-arrow-circle-right" />
+                </button>
+                <button
+                  type={isAccessionLike ? 'button' : 'submit'}
+                  onClick={
+                    !isAccessionLike
+                      ? null
+                      : () => {
+                          const searchText = searchBox.current.value;
+                          setSearchQuery(searchText);
+                          navigate('/search/submit');
+                        }
+                  }
+                  className={`vf-search__button | vf-button vf-button--${
+                    isAccessionLike ? 'secondary' : 'primary'
+                  }`}
+                >
+                  <span className="vf-button__text | vf-u-sr-only">Search</span>
 
-                <span className="icon icon-common icon-search" />
-              </button>
+                  <span className="icon icon-common icon-search" />
+                </button>
+              </div>
             </div>
             <div style={{ padding: '0 4px' }}>
               <p className="vf-text-body--5">

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -1,0 +1,20 @@
+.search-buttons-container {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    overflow: hidden;
+}
+
+.slide-in-hidden {
+    visibility: hidden;
+    transform: translateX(100%);
+}
+
+.slide-in-shown {
+    visibility: visible;
+    transform: translate(0);
+}
+
+.slide-in-button {
+    transition: transform 0.2s;
+}

--- a/src/utils/accessions.ts
+++ b/src/utils/accessions.ts
@@ -1,0 +1,41 @@
+export const studyAccessionPattern = /^MGYS[0-9]{8}$/;
+
+export const analysisAccessionPattern = /^MGYA[0-9]{8}$/;
+
+export const genomeAccessionPattern = /^MGYG[0-9]{9}$/;
+
+export const mgnifyAccessionPattern = /^MGY[AGSP]{1}[0-9]{1,12}$/;
+
+type DetailOrSearchURLType = {
+  isAccessionLike: boolean;
+  nextURL: string;
+};
+
+export const getDetailOrSearchURLForQuery = (
+  str: string
+): DetailOrSearchURLType => {
+  if (str.match(mgnifyAccessionPattern)) {
+    if (str.match(studyAccessionPattern)) {
+      return {
+        isAccessionLike: true,
+        nextURL: `/studies/${str}`,
+      };
+    }
+    if (str.match(analysisAccessionPattern)) {
+      return {
+        isAccessionLike: true,
+        nextURL: `/analyses/${str}`,
+      };
+    }
+    if (str.match(genomeAccessionPattern)) {
+      return {
+        isAccessionLike: true,
+        nextURL: `/genomes/${str}`,
+      };
+    }
+  }
+  return {
+    isAccessionLike: false,
+    nextURL: `/search/studies`,
+  };
+};


### PR DESCRIPTION
This PR:
- adds a button to the "hero header" search form which only appears if the search query looks like an Accession.

TODO later: add a similar pattern to the Text Search page. This is useful because it lets users jump to e.g. an MGYS that isn't yet in the EBI Search Index