### PR TITLE
Krona logo fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgportalv2",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgportalv2",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "ISC",
       "dependencies": {
         "@googlemaps/markerclustererplus": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mgportalv2",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Web Client for the Mgnify service at EBI",
   "homepage": "https://github.com/EBI-Metagenomics/ebi-metagenomics-client#readme",
   "main": "src/index.tsx",


### PR DESCRIPTION
The skewed Krona logo on older analysis, was being caused by a height and width property set on the img tag.
These properties were put in with the newer version of the logo in mind. Inadvertently, they were causing the older logos not to be displayed properly. 
This fix uses a js function to target the older logos and remove the undesired properties from them.