### PR TITLE
Clarify the citation for MGnify Genomes

### DIFF
--- a/src/components/Browse/Genomes/index.tsx
+++ b/src/components/Browse/Genomes/index.tsx
@@ -24,7 +24,7 @@ const BrowseGenomes: React.FC = () => {
 
   return (
     <section className="mg-browse-section">
-      <div>
+      <div className="vf-stack vf-stack--400">
         <p>
           Genome catalogues are biome-specific collections of
           metagenomic-assembled and isolate genomes. The latest version of each
@@ -35,6 +35,11 @@ const BrowseGenomes: React.FC = () => {
           </a>
           .
         </p>
+        <MainPublicationForResource
+          resource="genomes"
+          citationPretext="If you use the MGnify Genomes resource, please cite:"
+        />
+        <div />
       </div>
       <TabsForQueryParameter
         tabs={tabs}
@@ -49,12 +54,6 @@ const BrowseGenomes: React.FC = () => {
         {browseBy === 'mag-search' && <SourmashSearch />}
       </div>
       <hr className="vf-divider" />
-      <div className="vf-stack vf-stack--400">
-        <p className="vf-text-body vf-text-body--2">
-          If you use the MGnify Genomes resource, please cite:
-        </p>
-        <MainPublicationForResource resource="genomes" />
-      </div>
     </section>
   );
 };

--- a/src/components/Publications/index.tsx
+++ b/src/components/Publications/index.tsx
@@ -61,22 +61,26 @@ export const Publication: React.FC<{
 };
 export const MainPublicationForResource: React.FC<{
   resource: string;
-}> = ({ resource }) => {
+  citationPretext: string;
+}> = ({ resource, citationPretext }) => {
   const publication = publications.filter(
     (pub) => pub.isMainCitationFor && pub.isMainCitationFor.includes(resource)
   )?.[0];
   return (
-    <div>
+    <div className="mg-main-pub-resource">
       {publication && (
-        <Publication
-          id={publication.id}
-          title={publication.title}
-          journal={publication.journal}
-          year={publication.year}
-          link={publication.link}
-          doi={publication.doi}
-          authors={publication.authors}
-        />
+        <>
+          <p className="vf-text-body vf-text-body--3">{citationPretext}</p>
+          <Publication
+            id={publication.id}
+            title={publication.title}
+            journal={publication.journal}
+            year={publication.year}
+            link={publication.link}
+            doi={publication.doi}
+            authors={publication.authors}
+          />
+        </>
       )}
     </div>
   );
@@ -92,8 +96,10 @@ export const MainPublication: React.FC = () => {
         />
       </div>
       <div>
-        <p>To cite MGnify, please refer to the following publication:</p>
-        <MainPublicationForResource resource="mgnify" />
+        <MainPublicationForResource
+          resource="mgnify"
+          citationPretext="To cite MGnify, please refer to the following publication:"
+        />
       </div>
     </div>
   );

--- a/src/components/Publications/style.css
+++ b/src/components/Publications/style.css
@@ -24,3 +24,9 @@
     text-align: right;
   }
 }
+
+.mg-main-pub-resource {
+  border-left: 5px solid #18974c;
+  padding: 8px;
+  background-color: #f3f3f3;
+}


### PR DESCRIPTION
This PR:
- makes the "cite as" for MGnify Genomes more prominent on the Genomes resource page, as we found users were citing the main MGnify paper when using this sub-resource.

![screenshot](https://github.com/EBI-Metagenomics/ebi-metagenomics-client/assets/414767/7f14d4ad-58d4-4c56-b803-334f8a4f04d3)
