### PR TITLE
Add a filter for the IGV MultipleField component.

### DIFF
--- a/src/components/Genomes/Browser/Popup/index.tsx
+++ b/src/components/Genomes/Browser/Popup/index.tsx
@@ -36,7 +36,6 @@ const MultipleField: React.FC<{
 }> = ({ value, url, decodeValue, filterValue = () => true }) => {
   if (!value) return null;
   const parts = value.split(',').filter(filterValue);
-  if (!parts.length) return null;
   return (
     <ul className="vf-list">
       {parts.map((part) => {
@@ -101,6 +100,8 @@ const formatData = (
         el.value === null ? null : String(el.value);
     return memo;
   }, {});
+  // TODO: Implement using something similar to the TrackColourPicker.FORMAT to handle differences
+  const ecnumber = attributes.ec_number || attributes.ecnumber;
 
   const functionalData = {
     title: 'Functional annotation',
@@ -108,10 +109,10 @@ const formatData = (
       {
         name: 'E.C Number',
         Value:
-          attributes.ec_number &&
+          ecnumber &&
           (() => (
             <MultipleField
-              value={attributes.ec_number}
+              value={ecnumber}
               url="https://enzyme.expasy.org/EC/"
               filterValue={(ecNumber) => {
                 // https://en.wikipedia.org/wiki/Enzyme_Commission_number

--- a/src/components/Genomes/Browser/Popup/index.tsx
+++ b/src/components/Genomes/Browser/Popup/index.tsx
@@ -32,9 +32,10 @@ const MultipleField: React.FC<{
   value: string;
   url?: string;
   decodeValue?: boolean;
-}> = ({ value, url, decodeValue }) => {
+  filterValue?: (value: string) => boolean;
+}> = ({ value, url, decodeValue, filterValue = () => true }) => {
   if (!value) return null;
-  const parts = value.split(',');
+  const parts = value.split(',').filter(filterValue);
   return (
     <ul className="vf-list">
       {parts.map((part) => {
@@ -106,11 +107,15 @@ const formatData = (
       {
         name: 'E.C Number',
         Value:
-          attributes.ecnumber &&
+          attributes.ec_number &&
           (() => (
             <MultipleField
-              value={attributes.ecnumber}
+              value={attributes.ec_number}
               url="https://enzyme.expasy.org/EC/"
+              filterValue={(ecNumber) => {
+                // https://en.wikipedia.org/wiki/Enzyme_Commission_number
+                return /[n\d-]+\.[n\d-]+\.[n\d-]+\.[n\d-]+/.test(ecNumber);
+              }}
             />
           )),
       },
@@ -122,6 +127,9 @@ const formatData = (
             <MultipleField
               value={attributes.pfam}
               url="https://www.ebi.ac.uk/interpro/entry/pfam/"
+              filterValue={(pfamAccession) => {
+                return pfamAccession.startsWith('PF');
+              }}
             />
           )),
       },
@@ -133,6 +141,9 @@ const formatData = (
             <MultipleField
               value={attributes.kegg}
               url="https://www.genome.jp/dbget-bin/www_bget?"
+              filterValue={(keggAccession) => {
+                return keggAccession.startsWith('ko:K');
+              }}
             />
           )),
       },
@@ -153,6 +164,9 @@ const formatData = (
             <MultipleField
               value={attributes.go}
               url="https://www.ebi.ac.uk/ols/search?q="
+              filterValue={(goAccession) => {
+                return goAccession.startsWith('GO:');
+              }}
             />
           )),
       },
@@ -163,7 +177,10 @@ const formatData = (
           (() => (
             <MultipleField
               value={attributes.interpro}
-              url="https://www.ebi.ac.uk/interpro/entry/InterPro/'"
+              url="https://www.ebi.ac.uk/interpro/entry/InterPro/"
+              filterValue={(ipsAccession) => {
+                return ipsAccession.startsWith('IPR');
+              }}
             />
           )),
       },

--- a/src/components/Genomes/Browser/Popup/index.tsx
+++ b/src/components/Genomes/Browser/Popup/index.tsx
@@ -36,6 +36,7 @@ const MultipleField: React.FC<{
 }> = ({ value, url, decodeValue, filterValue = () => true }) => {
   if (!value) return null;
   const parts = value.split(',').filter(filterValue);
+  if (!parts.length) return null;
   return (
     <ul className="vf-list">
       {parts.map((part) => {


### PR DESCRIPTION
This filter is used to filter/validate GFF attributes. I've also included the filter rules for the following accessions:
- Pfam
- Interpro
- GO
- KEGG KO
- E.C numbers (using a regex)

This commit also includes a fix for the Interpro and EC links which were broken.

This fixes https://www.ebi.ac.uk/panda/jira/browse/EMG-5412 and https://www.ebi.ac.uk/panda/jira/browse/EMG-5411