### PR TITLE
Hotfix ncrna annotation track color

### DIFF
--- a/src/components/Genomes/Browser/index.tsx
+++ b/src/components/Genomes/Browser/index.tsx
@@ -42,12 +42,8 @@ const GenomeBrowser: React.FC = () => {
         ...trackColorBys,
         [trackId]: option,
       });
-      console.log('parent trackId', trackId);
-      console.log('parent option', option);
     }
-    if (option.value !== 'viphog') {
-      updateQueryParams('functional-annotation', option.value);
-    }
+    updateQueryParams('functional-annotation', option.value);
   };
 
   const igvContainer = useCallback(
@@ -109,8 +105,6 @@ const GenomeBrowser: React.FC = () => {
               ...trackColorBys,
               [options.tracks[0].name]: trackColorBy,
             });
-            console.log('child tracks', options.tracks[0].name);
-            console.log('child trackColorBy', trackColorBy);
           },
           setLoading
         );
@@ -130,23 +124,22 @@ const GenomeBrowser: React.FC = () => {
           ...trackView.track.config,
           ...annotationTrackCustomisations(colorBy.value, FORMAT.GENOME),
         };
-        console.log('newTrackConfig.nameField', newTrackConfig.nameField);
-        // check if track already added before adding it again:
-        let trackAlreadyAdded = false;
-        trackAlreadyAdded =
-          newTrackConfig.nameField === trackView.track.config.nameField;
-
-        tracksToAdd.push(newTrackConfig);
-        console.log('tracksToAdd', tracksToAdd);
-        // if (newTrackConfig.nameField !== trackView.track.config.nameField) {
-        //   // Prevent unnecessary track reloads
-        //   tracksToRemove.push(trackView.track.id);
-        //   tracksToAdd.push(newTrackConfig);
-        // }
+        if (newTrackConfig.nameField !== trackView.track.config.nameField) {
+          // Prevent unnecessary track reloads
+          tracksToRemove.push(trackView.track.id);
+          tracksToAdd.push(newTrackConfig);
+        }
       }
     });
-    tracksToRemove.forEach((track) => igvBrowser.removeTrackByName(track));
-    tracksToAdd.forEach((track) => igvBrowser.loadTrack(track));
+    tracksToRemove.forEach((track) => {
+      // console.log('track to remove', track);
+      // if (track === 'Functional annotation') return;
+      igvBrowser.removeTrackByName(track);
+    });
+    tracksToAdd.forEach((track) => {
+      // console.log('track to add', track.nameField);
+      igvBrowser.loadTrack(track);
+    });
   }, [trackColorBys, igvBrowser]);
 
   return (

--- a/src/components/Genomes/Browser/index.tsx
+++ b/src/components/Genomes/Browser/index.tsx
@@ -43,7 +43,9 @@ const GenomeBrowser: React.FC = () => {
         [trackId]: option,
       });
     }
-    updateQueryParams('functional-annotation', option.value);
+    if (trackId === 'Functional annotation') {
+      updateQueryParams('functional-annotation', option.value);
+    }
   };
 
   const igvContainer = useCallback(
@@ -132,12 +134,9 @@ const GenomeBrowser: React.FC = () => {
       }
     });
     tracksToRemove.forEach((track) => {
-      // console.log('track to remove', track);
-      // if (track === 'Functional annotation') return;
       igvBrowser.removeTrackByName(track);
     });
     tracksToAdd.forEach((track) => {
-      // console.log('track to add', track.nameField);
       igvBrowser.loadTrack(track);
     });
   }, [trackColorBys, igvBrowser]);

--- a/src/components/Genomes/Browser/index.tsx
+++ b/src/components/Genomes/Browser/index.tsx
@@ -42,8 +42,12 @@ const GenomeBrowser: React.FC = () => {
         ...trackColorBys,
         [trackId]: option,
       });
+      console.log('parent trackId', trackId);
+      console.log('parent option', option);
     }
-    updateQueryParams('functional-annotation', option.value);
+    if (option.value !== 'viphog') {
+      updateQueryParams('functional-annotation', option.value);
+    }
   };
 
   const igvContainer = useCallback(
@@ -105,6 +109,8 @@ const GenomeBrowser: React.FC = () => {
               ...trackColorBys,
               [options.tracks[0].name]: trackColorBy,
             });
+            console.log('child tracks', options.tracks[0].name);
+            console.log('child trackColorBy', trackColorBy);
           },
           setLoading
         );
@@ -124,11 +130,19 @@ const GenomeBrowser: React.FC = () => {
           ...trackView.track.config,
           ...annotationTrackCustomisations(colorBy.value, FORMAT.GENOME),
         };
-        if (newTrackConfig.nameField !== trackView.track.config.nameField) {
-          // Prevent unnecessary track reloads
-          tracksToRemove.push(trackView.track.id);
-          tracksToAdd.push(newTrackConfig);
-        }
+        console.log('newTrackConfig.nameField', newTrackConfig.nameField);
+        // check if track already added before adding it again:
+        let trackAlreadyAdded = false;
+        trackAlreadyAdded =
+          newTrackConfig.nameField === trackView.track.config.nameField;
+
+        tracksToAdd.push(newTrackConfig);
+        console.log('tracksToAdd', tracksToAdd);
+        // if (newTrackConfig.nameField !== trackView.track.config.nameField) {
+        //   // Prevent unnecessary track reloads
+        //   tracksToRemove.push(trackView.track.id);
+        //   tracksToAdd.push(newTrackConfig);
+        // }
       }
     });
     tracksToRemove.forEach((track) => igvBrowser.removeTrackByName(track));

--- a/src/components/IGV/TrackColourPicker/index.tsx
+++ b/src/components/IGV/TrackColourPicker/index.tsx
@@ -29,7 +29,7 @@ function maybeGetAttributeValue(feature, attrPossibleNames: string[]) {
 }
 
 function determineNcRnaPresence(feature) {
-  if (!feature || !feature.getAttributeValue) return null;
+  if (!feature || !feature?.type) return null;
   return feature.type === 'ncrna' || feature.type === 'ncRNA';
 }
 

--- a/src/components/IGV/TrackColourPicker/index.tsx
+++ b/src/components/IGV/TrackColourPicker/index.tsx
@@ -28,6 +28,15 @@ function maybeGetAttributeValue(feature, attrPossibleNames: string[]) {
   return null;
 }
 
+function maybeFeatureType(feature) {
+  if (feature.type === 'ncrna') {
+    console.log('type', feature);
+  }
+  if (!feature || !feature.getAttributeValue) return null;
+  // eslint-disable-next-line no-restricted-syntax
+  return feature.type === 'ncrna' || feature.type === 'ncRNA';
+}
+
 export const FORMAT = {
   GENOME: 'GENOME',
   ASSEMBLY_V5: 'ASSEMBLY_V5',
@@ -136,11 +145,9 @@ export const annotationTrackCustomisations = (trackColorBy, format) => {
       };
     case 'ncrna':
       return {
-        nameField: format === FORMAT.GENOME ? 'KEGG' : 'kegg',
+        nameField: format === FORMAT.GENOME ? 'ncRNA' : 'ncrna',
         color: (feature) =>
-          !maybeGetAttributeValue(feature, ['ncrna'])
-            ? COLOUR_ABSENCE
-            : COLOUR_PRESENCE,
+          maybeFeatureType(feature) ? COLOUR_PRESENCE : COLOUR_ABSENCE,
       };
     default:
       return {
@@ -205,6 +212,7 @@ const trackColorOptionsForType = (track) => {
               { label: 'MiBIG class', value: 'mibig' },
               { label: 'ViPhOG existence', value: 'viphog' },
               { label: 'CRISPR component', value: 'crispr' },
+              { label: 'ncRNA existence', value: 'ncrna' },
             ],
           },
         ],

--- a/src/components/IGV/TrackColourPicker/index.tsx
+++ b/src/components/IGV/TrackColourPicker/index.tsx
@@ -28,12 +28,8 @@ function maybeGetAttributeValue(feature, attrPossibleNames: string[]) {
   return null;
 }
 
-function maybeFeatureType(feature) {
-  if (feature.type === 'ncrna') {
-    console.log('type', feature);
-  }
+function determineNcRnaPresence(feature) {
   if (!feature || !feature.getAttributeValue) return null;
-  // eslint-disable-next-line no-restricted-syntax
   return feature.type === 'ncrna' || feature.type === 'ncRNA';
 }
 
@@ -147,7 +143,7 @@ export const annotationTrackCustomisations = (trackColorBy, format) => {
       return {
         nameField: format === FORMAT.GENOME ? 'ncRNA' : 'ncrna',
         color: (feature) =>
-          maybeFeatureType(feature) ? COLOUR_PRESENCE : COLOUR_ABSENCE,
+          determineNcRnaPresence(feature) ? COLOUR_PRESENCE : COLOUR_ABSENCE,
       };
     default:
       return {
@@ -236,7 +232,11 @@ export const AnnotationTrackColorPicker: React.FC<
   );
   const existingSelection = trackColorBys[trackView.track.id];
   useEffectOnce(() => {
-    if (!existingSelection) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const functionalAnnotationValueAlreadySet = urlParams.get(
+      'functional-annotation'
+    );
+    if (!existingSelection && !functionalAnnotationValueAlreadySet) {
       //   First mount of selector widget and no config already set.
       //   Set to predefined default.
       const defaultOption = find(options, (o) => o.value === defaultValue);

--- a/src/utils/igvBrowserHelper.ts
+++ b/src/utils/igvBrowserHelper.ts
@@ -2,6 +2,7 @@ import { Dispatch } from 'react';
 import { Browser } from 'igv';
 
 export const updateQueryParams = (key: string, value: string) => {
+  if (value === 'viphog') return;
   const currentUrl = new URL(window.location.href);
   currentUrl.searchParams.set(key, value);
   const updatedUrl = currentUrl.toString();

--- a/src/utils/igvBrowserHelper.ts
+++ b/src/utils/igvBrowserHelper.ts
@@ -2,7 +2,6 @@ import { Dispatch } from 'react';
 import { Browser } from 'igv';
 
 export const updateQueryParams = (key: string, value: string) => {
-  if (value === 'viphog') return;
   const currentUrl = new URL(window.location.href);
   currentUrl.searchParams.set(key, value);
   const updatedUrl = currentUrl.toString();


### PR DESCRIPTION
Genomes that have more than one track color picker, were failing to load functional-annotation values that were preset from the query params. This was caused by the defaultValue functionality, which was originally written without consideration to deep linked values from query params. This pull request contains an adjustment that addresses this problem