### PR TITLE
Hotfix/associated study links

### DIFF
--- a/src/components/Study/Overview/index.tsx
+++ b/src/components/Study/Overview/index.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react';
-import { Link } from 'react-router-dom';
 import { Publication } from 'components/Publications';
 import AnalysesTable from 'components/Analysis/Analyses';
 import Box from 'components/UI/Box';

--- a/src/components/Study/Overview/index.tsx
+++ b/src/components/Study/Overview/index.tsx
@@ -60,7 +60,7 @@ const StudyOverview: React.FC<StudyOverviewProps> = ({ data, included }) => {
             <ul className="vf-list">
               {data.relationships.studies.data.map(({ id }) => (
                 <li key={id as string}>
-                  <Link to={`/studies/${id}`}>{id}</Link>
+                  <a href={`/metagenomics/studies/${id}`}>{id}</a>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
Clicking on related studies links on the Study page, was navigating users to the same study (Not to the intended related one)
This pull request addresses that issue by using a regular anchor tag rather than the custom <Link> component 