### PR TITLE
stopped loader from going on, when no contig is found

### DIFF
--- a/src/components/Analysis/ContigViewer/index.tsx
+++ b/src/components/Analysis/ContigViewer/index.tsx
@@ -273,6 +273,13 @@ const ContigsViewer: React.FC = () => {
     }
   }, [data, contig, setSelectedContigParam]);
 
+  const showContigOrLoader = () => {
+    if (!contig && !loading) return <p>No contig found</p>;
+    if (loading) return <Loading size="small" />;
+    if (error) return <FetchError error={error} />;
+    return <Contig contig={contig} />;
+  };
+
   if (error) return <FetchError error={error} />;
   return (
     <div className="vf-stack vf-stack--800">
@@ -283,10 +290,7 @@ const ContigsViewer: React.FC = () => {
               <summary>
                 <h4>Contig browser</h4>
               </summary>
-              <div className="contig-igv-container">
-                {!!contig && <Contig contig={contig} />}
-                {!contig && <Loading size="small" />}
-              </div>
+              <div className="contig-igv-container">{showContigOrLoader()}</div>
             </details>
           </div>
         </section>


### PR DESCRIPTION
In response to the issue created here: https://www.ebi.ac.uk/panda/jira/secure/RapidBoard.jspa?rapidView=91&projectKey=EMG&view=planning&selectedIssue=EMG-5421&issueLimit=100

Previously, when a contig is not found on the API, the loader of the contig browser keeps spinning infinitely. 
This pull request addresses this issue by displaying a not found message when such an incident occurs. 

![Screenshot 2024-02-01 at 11 34 04](https://github.com/EBI-Metagenomics/ebi-metagenomics-client/assets/28231792/5c876b2e-efc8-4f2a-aee1-c65bf0cdfa4d)
