### PR TITLE
Hotfix/mega menu styling ii

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgportalv2",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgportalv2",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "ISC",
       "dependencies": {
         "@googlemaps/markerclustererplus": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mgportalv2",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Web Client for the Mgnify service at EBI",
   "homepage": "https://github.com/EBI-Metagenomics/ebi-metagenomics-client#readme",
   "main": "src/index.tsx",

--- a/src/App.css
+++ b/src/App.css
@@ -118,3 +118,8 @@ pre.vf-code-example__pre > button {
     cursor: help;
     text-decoration: none;
 }
+
+#mgnify-mega-menu .vf-navigation__link:visited:hover {
+  color: #3b6fb6;
+  text-decoration: underline;
+}

--- a/src/components/Nav/MegaMenu/index.tsx
+++ b/src/components/Nav/MegaMenu/index.tsx
@@ -23,8 +23,8 @@ const MegaMenu: React.FC = () => {
   };
 
   const handleMouseLeave = () => {
-    // setMenuVisible(false);
-    // setActiveSection(null);
+    setMenuVisible(false);
+    setActiveSection(null);
   };
 
   const searchBox = useRef<HTMLInputElement>();

--- a/src/components/Nav/MegaMenu/index.tsx
+++ b/src/components/Nav/MegaMenu/index.tsx
@@ -23,8 +23,8 @@ const MegaMenu: React.FC = () => {
   };
 
   const handleMouseLeave = () => {
-    setMenuVisible(false);
-    setActiveSection(null);
+    // setMenuVisible(false);
+    // setActiveSection(null);
   };
 
   const searchBox = useRef<HTMLInputElement>();
@@ -51,7 +51,11 @@ const MegaMenu: React.FC = () => {
 
   return (
     <div onMouseLeave={handleMouseLeave}>
-      <div className="vf-global-header vf-mega-menu" role="menubar">
+      <div
+        id="mgnify-mega-menu"
+        className="vf-global-header vf-mega-menu"
+        role="menubar"
+      >
         <nav className="vf-navigation | vf-cluster">
           <ul className="vf-navigation__list | vf-list | vf-cluster__inner">
             <li className="vf-navigation__item">


### PR DESCRIPTION
By default, the VF adds a default visited styling to to level links on the megamenu. Causing the color to go dark when a link has been previously visited. 
This detracts away from the intended look of the megamenu. 
This pull request adds some CSS to prevent the default behaviour


![Screenshot 2024-02-12 at 12 07 57](https://github.com/EBI-Metagenomics/ebi-metagenomics-client/assets/28231792/260d83a5-6cc3-4625-a64f-d5ea7df4b696)
![Screenshot 2024-02-12 at 12 08 51](https://github.com/EBI-Metagenomics/ebi-metagenomics-client/assets/28231792/7f5e0551-25a5-4221-a1f2-8b8b4ef2dcbd)
