### PR TITLE
Feature: Offline RO-Crate comparer

### DIFF
--- a/src/components/Analysis/ContigViewer/Table/index.tsx
+++ b/src/components/Analysis/ContigViewer/Table/index.tsx
@@ -12,7 +12,10 @@ import CursorPagination from 'components/UI/EMGTable/CursorPagination';
 import TruncatedText from 'components/UI/TextTruncated';
 import useQueryParamState from 'hooks/queryParamState/useQueryParamState';
 import AnalysisContext from 'pages/Analysis/AnalysisContext';
-import { useCrates } from 'hooks/genomeViewer/CrateStore/useCrates';
+import {
+  useCrates,
+  useOfflineCrate,
+} from 'hooks/genomeViewer/CrateStore/useCrates';
 
 type ContigFeatureProps = {
   annotationType: string;
@@ -79,6 +82,16 @@ const ContigsTable: React.FC = () => {
   const { crates, loading: loadingCrates } = useCrates(
     `assemblies/${assemblyId}/extra-annotations`
   );
+  const { crate: offlineCrate, isUploading: loadingOfflineCrate } =
+    useOfflineCrate();
+
+  const allCrates = useMemo(() => {
+    const cratesIncludingOffline = [...crates] || [];
+    if (offlineCrate) {
+      cratesIncludingOffline.push(offlineCrate);
+    }
+    return cratesIncludingOffline;
+  }, [crates, offlineCrate]);
 
   const contigsColumns = useMemo(() => {
     const cols = [
@@ -127,13 +140,13 @@ const ContigsTable: React.FC = () => {
         },
       },
     ];
-    if (crates) {
+    if (allCrates) {
       cols.push({
         id: 'crates',
         Header: 'RO-Crates',
         accessor: (contig) => contig.attributes['contig-id'],
         Cell: ({ cell }) => {
-          const crateFlags = crates.map((crate) => (
+          const crateFlags = allCrates.map((crate) => (
             <ContigFeatureFlag
               key={crate.url}
               annotationType={crate.track.label.substring(0)}
@@ -145,7 +158,7 @@ const ContigsTable: React.FC = () => {
       });
     }
     return cols;
-  }, [setSelectedContig, crates]);
+  }, [setSelectedContig, allCrates]);
 
   if (error || !data) return <FetchError error={error} />;
 
@@ -159,7 +172,7 @@ const ContigsTable: React.FC = () => {
         initialPage={0}
         className="mg-contigs-table"
         namespace="contigs_"
-        isStale={loading || loadingCrates}
+        isStale={loading || loadingCrates || loadingOfflineCrate}
         showTextFilter
       />
       <CursorPagination

--- a/src/components/Analysis/ContigViewer/index.tsx
+++ b/src/components/Analysis/ContigViewer/index.tsx
@@ -36,8 +36,12 @@ import {
   FORMAT,
 } from 'components/IGV/TrackColourPicker';
 import AnalysisContext from 'pages/Analysis/AnalysisContext';
-import { useCrates } from 'hooks/genomeViewer/CrateStore/useCrates';
+import {
+  useCrates,
+  useOfflineCrate,
+} from 'hooks/genomeViewer/CrateStore/useCrates';
 import { Track } from 'utils/trackView';
+import ROCrateComparer from 'components/UI/ROCrateComparer';
 
 type ContigProps = {
   contig: MGnifyDatum;
@@ -57,6 +61,8 @@ const Contig: React.FC<ContigProps> = ({ contig }) => {
   const { crates, loading: loadingCrates } = useCrates(
     `assemblies/${assemblyId}/extra-annotations`
   );
+
+  const { crate: offlineCrate } = useOfflineCrate();
 
   const antiSMASH = contig.attributes['has-antismash'];
   const displayName = contig.attributes['contig-name'];
@@ -106,6 +112,9 @@ const Contig: React.FC<ContigProps> = ({ contig }) => {
           options.tracks.push(crate.track);
         });
       }
+      if (offlineCrate) {
+        options.tracks.push(offlineCrate.track);
+      }
 
       if (node === null) return;
       igv.createBrowser(node, options).then((browser) => {
@@ -115,7 +124,16 @@ const Contig: React.FC<ContigProps> = ({ contig }) => {
         setIgvBrowser(browser);
       });
     },
-    [fastaURL, displayName, config.api, accession, contigId, antiSMASH, crates]
+    [
+      fastaURL,
+      displayName,
+      config.api,
+      accession,
+      contigId,
+      antiSMASH,
+      crates,
+      offlineCrate,
+    ]
   );
 
   useEffect(() => {
@@ -178,6 +196,7 @@ const Contig: React.FC<ContigProps> = ({ contig }) => {
               />
             );
           })}
+          <ROCrateComparer />
         </div>
       )}
     </div>

--- a/src/components/UI/FetchError/index.tsx
+++ b/src/components/UI/FetchError/index.tsx
@@ -8,7 +8,7 @@ const refreshPage = (): void => {
 const getHumanReadableErrorMessages = (error: ErrorFromFetch): string => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const errorStatusCode = error.error.response.status;
+  const errorStatusCode = error.error.response?.status || error.error.code;
   switch (errorStatusCode) {
     case 404:
       return '404: The requested resource could not be found.';
@@ -36,7 +36,7 @@ const FetchError: React.FC<{ error: ErrorFromFetch }> = ({ error }) => {
         {error?.type === ErrorTypes.FetchError &&
           `There were problems with the request. ${getHumanReadableErrorMessages(
             error
-          )}.`}
+          )}`}
         {error?.type === ErrorTypes.NotOK &&
           `The response from the server was not OK [Status: ${error.status}].`}
         {error?.type === ErrorTypes.JSONError &&
@@ -44,7 +44,7 @@ const FetchError: React.FC<{ error: ErrorFromFetch }> = ({ error }) => {
       </p>
       <details className="vf-details" open>
         <summary className="vf-details--summary">Advanced</summary>
-        Request endpoint: {error.error.request.responseURL}
+        Request endpoint: {error.error.request.responseURL || error.error.config.url}
       </details>
       <div className="mg-right">
         <button

--- a/src/components/UI/FetchError/index.tsx
+++ b/src/components/UI/FetchError/index.tsx
@@ -44,7 +44,8 @@ const FetchError: React.FC<{ error: ErrorFromFetch }> = ({ error }) => {
       </p>
       <details className="vf-details" open>
         <summary className="vf-details--summary">Advanced</summary>
-        Request endpoint: {error.error.request.responseURL || error.error.config.url}
+        Request endpoint:{' '}
+        {error.error.request.responseURL || error.error.config.url}
       </details>
       <div className="mg-right">
         <button

--- a/src/components/UI/ROCrateComparer/index.tsx
+++ b/src/components/UI/ROCrateComparer/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useOfflineCrate } from 'hooks/genomeViewer/CrateStore/useCrates';
+
+const ROCrateComparer = () => {
+  const { crate, uploadCrate, isUploading, removeCrate } = useOfflineCrate();
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      uploadCrate(file);
+    }
+  };
+
+  const handleButtonClick = () => {
+    document.getElementById('fileInput').click();
+  };
+
+  return (
+    <div>
+      <input
+        type="file"
+        onChange={handleFileChange}
+        id="fileInput"
+        style={{ display: 'none' }}
+      />
+      <div className="vf-stack vf-stack--200">
+        <p className="vf-form__label">Compare another track</p>
+        <div>
+          {!crate && (
+            <button
+              onClick={handleButtonClick}
+              className="vf-button vf-button--sm"
+              type="button"
+              disabled={isUploading}
+            >
+              {isUploading ? 'Adding...' : 'Add offline RO-Crate'}
+            </button>
+          )}
+          {!!crate && (
+            <button
+              className="vf-button vf-button--sm vf-button--link"
+              type="button"
+              onClick={removeCrate}
+            >
+              Clear offline RO-Crate
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ROCrateComparer;

--- a/src/hooks/data/useData/index.tsx
+++ b/src/hooks/data/useData/index.tsx
@@ -114,11 +114,15 @@ export type BlogResponse = {
 };
 
 export type ErrorFromFetch = {
+  code?: string;
   status?: number;
   response?: Promise<Response>;
   type: ErrorTypes;
   // error?: unknown | { message: string };
   error?: {
+    config?: {
+      url?: string;
+    };
     message: string;
     request: {
       responseURL: string;

--- a/src/hooks/genomeViewer/CrateStore/crate_db.ts
+++ b/src/hooks/genomeViewer/CrateStore/crate_db.ts
@@ -28,4 +28,8 @@ export class ROCrateDB extends Dexie {
   }
 }
 
+export const isOfflineCrate = (crate: StorableCrate): boolean => {
+  return crate.url.startsWith('file:///');
+};
+
 export const db = new ROCrateDB();


### PR DESCRIPTION
This PR:
- adds an "offline RO Crate" comparison feature to the contig browser
  - this is mostly for MetaPUF, but should be compatible with our other supported flavours of GFF-in-a-RO-crate (e.g. Sanntis)
  - it lets the user "upload" (well, store in their browser's indexed db) an RO-Crate flavoured like Sanntis, MetaPUF etc ones - basically a GFF file with some metadata.
  - this GFF is then shown as additional track on the contig browser
  - the idea is that a user can run a smaller pipeline like MetaPUF themselves, and visualise the results using MGnify
  - only one "offline crate" is supported at a time, currently. The crate persists between sessions and between contig switching though.
  - a nice enhancement would be to store multiple crates, keyed to the MGYA, so that a user can jump between multiple MGYAs whilst not losing their work. I didn't do this for now, as we would need to carefully manage the DB size given browser limitations.
- fixes a regression bug, where the human readable 

# Graphical changes:
## New feature
![Screenshot 2024-09-30 at 15 48 55](https://github.com/user-attachments/assets/fbd50249-4e52-48be-9a89-0aa4b7e524f2)



## Bugfix
![Screenshot 2024-09-30 at 15 50 58](https://github.com/user-attachments/assets/f919dcd6-3326-4591-a967-c04b25228166)
