### PR TITLE
Feature/genomes proteins on nav

### DIFF
--- a/cypress/e2e/about.js
+++ b/cypress/e2e/about.js
@@ -3,8 +3,7 @@ import {openPage} from '../util/util';
 describe('About page', { retries: 3 }, function() {
     context('Dropdown citations view', function() {
         it('Contains all the about sections', function() {
-            openPage('');
-            cy.get(`.mg-main-menu`).contains('About').click();
+            openPage('about');
             const content = '.about-page';
             cy.get(content).contains('The MGnify resource');
             cy.get(content).contains('Staying informed');
@@ -13,8 +12,7 @@ describe('About page', { retries: 3 }, function() {
             cy.get(content).contains('Funding');
         });
         it('Clicking button should display / hide publications', function() {
-            openPage('');
-            cy.get(`.mg-main-menu`).contains('About').click();
+            openPage('about');
             const citationDiv = '.mg-pub-section';
             const button = '.mg-pub-section button';
             console.log('button', button);

--- a/src/components/Nav/MainMenu/index.tsx
+++ b/src/components/Nav/MainMenu/index.tsx
@@ -24,8 +24,12 @@ const pages: Array<{ label: string; path?: string; href?: string }> = [
     path: 'https://www.ebi.ac.uk/ena/submit/webin/accountInfo',
   },
   { label: 'Text search', path: '/search' },
-  { label: 'Sequence search' },
   { label: 'Browse data', path: '/browse' },
+  {
+    label: 'MGnify Proteins',
+    path: 'https://www.ebi.ac.uk/metagenomics/proteins',
+  },
+  { label: 'MGnify Genomes', path: '/browse/genomes' },
   { label: 'API' },
   { label: 'About', path: '/about' },
   { label: 'Help', path: '/help' },

--- a/src/components/Nav/MegaMenu/index.tsx
+++ b/src/components/Nav/MegaMenu/index.tsx
@@ -126,19 +126,6 @@ const MegaMenu: React.FC = () => {
             </li>
             <li className="vf-navigation__item">
               <a
-                id="sequence-search-link"
-                target="_blank"
-                href="https://www.ebi.ac.uk/metagenomics/sequence-search/search/phmmer"
-                className="vf-navigation__link vf-mega-menu__link"
-                onClick={() => setMenuVisible(false)}
-                rel="noreferrer"
-              >
-                Sequence search &nbsp;
-                <span className="icon icon-common icon-external-link-alt" />
-              </a>
-            </li>
-            <li className="vf-navigation__item">
-              <a
                 id="browse-section"
                 className={`vf-navigation__link vf-mega-menu__link vf-mega-menu__link--has-section ${
                   activeSection === 'browse-section' ? 'active' : ''
@@ -151,15 +138,32 @@ const MegaMenu: React.FC = () => {
                 Browse data
               </a>
             </li>
-
             <li className="vf-navigation__item">
               <a
-                id="about-link"
-                className="vf-navigation__link vf-mega-menu__link"
-                href="/metagenomics/about"
-                onClick={() => setMenuVisible(false)}
+                id="proteins-section"
+                className={`vf-navigation__link vf-mega-menu__link vf-mega-menu__link--has-section ${
+                  activeSection === 'proteins-section' ? 'active' : ''
+                }`}
+                href="/metagenomics/proteins"
+                onClick={(event) =>
+                  handleMenuItemClick(event, 'proteins-section')
+                }
               >
-                About
+                MGnify Proteins
+              </a>
+            </li>
+            <li className="vf-navigation__item">
+              <a
+                id="proteins-section"
+                className={`vf-navigation__link vf-mega-menu__link vf-mega-menu__link--has-section ${
+                  activeSection === 'genomes-section' ? 'active' : ''
+                }`}
+                href="/metagenomics/browse"
+                onClick={(event) =>
+                  handleMenuItemClick(event, 'genomes-section')
+                }
+              >
+                MGnify Genomes
               </a>
             </li>
 
@@ -299,6 +303,113 @@ const MegaMenu: React.FC = () => {
                           >
                             API &nbsp;
                             <span className="icon icon-common icon-external-link-alt" />
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+              </section>
+            </div>
+          )}
+          {activeSection === 'proteins-section' && (
+            <div
+              className="vf-mega-menu__content__section"
+              id="browse-content-section"
+              role="menu"
+              aria-hidden={activeSection !== 'proteins-section'}
+            >
+              <section className="vf-summary-container | embl-grid">
+                <div className="vf-section-header">
+                  <h2 className="vf-section-header__heading">
+                    MGnify Proteins
+                  </h2>
+                  <p className="vf-section-header__text">
+                    MGnify Protein sequences are derived from the analysis of
+                    publicly available metagenomics assemblies within MGnify.
+                  </p>
+                </div>
+                <div className="vf-section-content | vf-grid vf-grid__col-3">
+                  <div>
+                    <nav className="vf-navigation vf-navigation--main">
+                      <ul className="vf-navigation__list | vf-list | vf-cluster__inner | vf-stack vf-stack--200">
+                        <li className="vf-navigation__item">
+                          <a
+                            href="/metagenomics/proteins"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Browse proteins <ArrowForLink />
+                          </a>
+                        </li>
+                        <li className="vf-navigation__item">
+                          <a
+                            href="https://www.ebi.ac.uk/metagenomics/sequence-search/search/phmmer"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Proteins sequence search <ArrowForLink />
+                          </a>
+                        </li>
+                        <li className="vf-navigation__item">
+                          <a
+                            href="https://ftp.ebi.ac.uk/pub/databases/metagenomics/peptide_database/"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Download database releases <ArrowForLink />
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  </div>
+                </div>
+              </section>
+            </div>
+          )}
+          {activeSection === 'genomes-section' && (
+            <div
+              className="vf-mega-menu__content__section"
+              id="browse-content-section"
+              role="menu"
+              aria-hidden={activeSection !== 'genomes-section'}
+            >
+              <section className="vf-summary-container | embl-grid">
+                <div className="vf-section-header">
+                  <h2 className="vf-section-header__heading">MGnify Genomes</h2>
+                  <p className="vf-section-header__text">
+                    MGnify Genomes are biome-specific catalogues of
+                    metagenomic-assembled and isolate microbial genomes.
+                  </p>
+                </div>
+                <div className="vf-section-content | vf-grid vf-grid__col-3">
+                  <div>
+                    <nav className="vf-navigation vf-navigation--main">
+                      <ul className="vf-navigation__list | vf-list | vf-cluster__inner | vf-stack vf-stack--200">
+                        <li className="vf-navigation__item">
+                          <a
+                            href="/metagenomics/browse/genomes"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Browse genomes <ArrowForLink />
+                          </a>
+                        </li>
+                        <li className="vf-navigation__item">
+                          <a
+                            href="http://branchwater-dev.mgnify.org/"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Branchwater search
+                            <ArrowForLink />
+                          </a>
+                          <p>
+                            Branchwater searches a large set of metagenomes for
+                            genome presence
+                          </p>
+                        </li>
+                        <li className="vf-navigation__item">
+                          <a
+                            href="https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/"
+                            className="vf-navigation__link rotating-link"
+                          >
+                            Browse all catalogue versions <ArrowForLink />
                           </a>
                         </li>
                       </ul>
@@ -509,6 +620,11 @@ const MegaMenu: React.FC = () => {
                   <h2 className="vf-section-header__heading">Help</h2>
                   <p className="vf-section-header__text">
                     Find out more about MGnify
+                    <br />
+                    <a className="vf-link" href="/metagenomics/about">
+                      About MGnify
+                    </a>
+                    <br />
                     <br />
                     <a className="vf-link" href="/metagenomics/help">
                       Go to the help page


### PR DESCRIPTION
This PR:
- adds "MGnify Proteins" and "MGnify Genomes" sections to the nav bars. This makes them more visible, now that there are multiple components to each of these subservices. Proteins contains sequence search and the MGnify Proteins landing page. Genome contains the catalogues link, branchwater link, and the FTP.

<img width="1769" height="1193" alt="image" src="https://github.com/user-attachments/assets/ad51dbe9-03ff-4a88-b3c4-4bee3a4ff43b" />
