### PR TITLE
Feature/generalised data hooks

### DIFF
--- a/src/components/Browse/Biomes/index.tsx
+++ b/src/components/Browse/Biomes/index.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
 import EMGTable from 'components/UI/EMGTable';
-import useMGnifyData from '@/hooks/data/useMGnifyData';
-import { MGnifyResponseList } from '@/hooks/data/useData';
 import { getBiomeIcon } from '@/utils/biomes';
 import Loading from 'components/UI/Loading';
 import Link from 'components/UI/Link';
 import { SharedTextQueryParam } from '@/hooks/queryParamState/QueryParamStore/QueryParamContext';
 import { createSharedQueryParamContextForTable } from '@/hooks/queryParamState/useQueryParamState';
+import useBiomesList from '@/hooks/data/useBiomes';
+import { Biome } from '@/interfaces';
 
 const {
   useBiomesPage,
@@ -28,9 +28,9 @@ const BrowseBiomes: React.FC = () => {
   const {
     data: biomesList,
     loading,
-    isStale,
-    downloadURL,
-  } = useMGnifyData('biomes', {
+    stale: isStale,
+    download: downloadURL,
+  } = useBiomesList({
     page,
     ordering: order,
     page_size: pageSize,
@@ -42,7 +42,7 @@ const BrowseBiomes: React.FC = () => {
       {
         id: 'biome',
         Header: '',
-        accessor: 'id',
+        accessor: 'lineage',
         Cell: ({ cell }) => (
           <span className={`biome_icon icon_xs ${getBiomeIcon(cell.value)}`} />
         ),
@@ -52,9 +52,9 @@ const BrowseBiomes: React.FC = () => {
       {
         id: 'biome_name',
         Header: 'Biome name and lineage',
-        accessor: (biome) => ({
-          lineage: biome.attributes.lineage,
-          name: biome.attributes['biome-name'],
+        accessor: (biome: Biome) => ({
+          lineage: biome.lineage,
+          name: biome.biome_name,
         }),
         Cell: ({ cell }) => (
           <>
@@ -69,9 +69,9 @@ const BrowseBiomes: React.FC = () => {
       {
         Header: 'Samples excluding sub-lineages',
         id: 'samples_count',
-        accessor: (biome) => ({
-          lineage: biome.attributes.lineage,
-          count: biome.attributes['samples-count'],
+        accessor: (biome: Biome) => ({
+          lineage: biome.lineage,
+          count: (biome as any).samples_count,
         }),
         Cell: ({ cell }) => (
           <Link to={`/browse/samples?biome=${cell.value.lineage}`}>
@@ -91,16 +91,16 @@ const BrowseBiomes: React.FC = () => {
   return (
     <section className="mg-browse-section">
       {hasData && (
-        <EMGTable
+        <EMGTable<Biome>
           cols={columns}
-          data={biomesList as MGnifyResponseList}
-          Title={`Biomes (${biomesList.meta.pagination.count})`}
+          data={biomesList?.items ?? []}
+          Title={`Biomes (${biomesList?.count})`}
           initialPage={(page as number) - 1}
           sortable
           loading={loading}
           isStale={isStale}
           showTextFilter
-          downloadURL={downloadURL}
+          onDownloadRequested={downloadURL}
         />
       )}
     </section>

--- a/src/hooks/data/useBiomes/index.tsx
+++ b/src/hooks/data/useBiomes/index.tsx
@@ -1,25 +1,9 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { BiomeList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useBiomesList = (parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}biomes/${queryString ? `?${queryString}` : ''}`;
-
-  return useApiData<BiomeList>({
-    url,
-  });
+  return useMgnifyResourceList<BiomeList>('biomes', parameters);
 };
 
 export default useBiomesList;

--- a/src/hooks/data/useMgnifyResourceDetail/index.tsx
+++ b/src/hooks/data/useMgnifyResourceDetail/index.tsx
@@ -1,0 +1,16 @@
+import UserContext from 'pages/Login/UserContext';
+import { useContext } from 'react';
+
+import useApiData from 'hooks/data/useApiData';
+
+const useMgnifyResourceDetail = <T,>(resource: string, id: string | number) => {
+  const { config } = useContext(UserContext);
+
+  const url = `${config.api_v2}${resource}/${id}`;
+
+  return useApiData<T>({
+    url,
+  });
+};
+
+export default useMgnifyResourceDetail;

--- a/src/hooks/data/useMgnifyResourceList/index.tsx
+++ b/src/hooks/data/useMgnifyResourceList/index.tsx
@@ -11,7 +11,7 @@ const useMgnifyResourceList = <T,>(
   const { config } = useContext(UserContext);
 
   const queryString = Object.entries(parameters)
-    .filter(([, value]) => value !== undefined)
+    .filter(([, value]) => value !== undefined && value !== '')
     .map(
       ([key, value]) =>
         `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`

--- a/src/hooks/data/useMgnifyResourceList/index.tsx
+++ b/src/hooks/data/useMgnifyResourceList/index.tsx
@@ -1,0 +1,30 @@
+import UserContext from 'pages/Login/UserContext';
+import { useContext } from 'react';
+
+import useApiData from 'hooks/data/useApiData';
+import { KeyValue } from 'hooks/data/useData';
+
+const useMgnifyResourceList = <T,>(
+  resource: string,
+  parameters: KeyValue = {}
+) => {
+  const { config } = useContext(UserContext);
+
+  const queryString = Object.entries(parameters)
+    .filter(([, value]) => value !== undefined)
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+    )
+    .join('&');
+
+  const url = `${config.api_v2}${resource}/${
+    queryString ? `?${queryString}` : ''
+  }`;
+
+  return useApiData<T>({
+    url,
+  });
+};
+
+export default useMgnifyResourceList;

--- a/src/hooks/data/usePublicationDetail/index.tsx
+++ b/src/hooks/data/usePublicationDetail/index.tsx
@@ -1,26 +1,20 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import {
   PublicationDetail,
   PublicationEuropePmcCore,
   PublicationEuropePmcAnnotations,
 } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
+import useMgnifyResourceDetail from 'hooks/data/useMgnifyResourceDetail';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 import axios from 'axios';
 
 const usePublicationDetail = (pubmedId: number) => {
-  const { config } = useContext(UserContext);
-
-  const url = `${config.api_v2}publications/${pubmedId}`;
-
   const abstractGetter = () => {
     const europePmcUrl = `https://www.ebi.ac.uk/europepmc/webservices/rest/article/MED/${pubmedId}?format=json&resultType=core`;
     return axios.get<PublicationEuropePmcCore>(europePmcUrl);
   };
 
   return {
-    ...useApiData<PublicationDetail>({ url }),
+    ...useMgnifyResourceDetail<PublicationDetail>('publications', pubmedId),
     abstractGetter,
   };
 };
@@ -28,9 +22,7 @@ const usePublicationDetail = (pubmedId: number) => {
 export default usePublicationDetail;
 
 export const usePublicationAnnotations = (pubmedId: number) => {
-  const { config } = useContext(UserContext);
-
-  const url = `${config.api_v2}publications/${pubmedId}/annotations`;
-
-  return useApiData<PublicationEuropePmcAnnotations>({ url });
+  return useMgnifyResourceList<PublicationEuropePmcAnnotations>(
+    `publications/${pubmedId}/annotations`
+  );
 };

--- a/src/hooks/data/usePublications/index.tsx
+++ b/src/hooks/data/usePublications/index.tsx
@@ -1,27 +1,9 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { PublicationList } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const usePublicationsList = (parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}publications/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<PublicationList>({
-    url,
-  });
+  return useMgnifyResourceList<PublicationList>('publications', parameters);
 };
 
 export default usePublicationsList;

--- a/src/hooks/data/useRunAnalysesList/index.tsx
+++ b/src/hooks/data/useRunAnalysesList/index.tsx
@@ -1,27 +1,12 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { AnalysisList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useRunAnalysesList = (accession: string, parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}runs/${accession}/analyses/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<AnalysisList>({
-    url,
-  });
+  return useMgnifyResourceList<AnalysisList>(
+    `runs/${accession}/analyses`,
+    parameters
+  );
 };
 
 export default useRunAnalysesList;

--- a/src/hooks/data/useRunAssemblies/index.tsx
+++ b/src/hooks/data/useRunAssemblies/index.tsx
@@ -1,27 +1,12 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { AssemblyList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useRunAssemblies = (accession: string, parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}runs/${accession}/assemblies/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<AssemblyList>({
-    url,
-  });
+  return useMgnifyResourceList<AssemblyList>(
+    `runs/${accession}/assemblies`,
+    parameters
+  );
 };
 
 export default useRunAssemblies;

--- a/src/hooks/data/useRunDetail/index.tsx
+++ b/src/hooks/data/useRunDetail/index.tsx
@@ -1,17 +1,8 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { RunDetail } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
+import useMgnifyResourceDetail from 'hooks/data/useMgnifyResourceDetail';
 
 const useRunDetail = (accession: string) => {
-  const { config } = useContext(UserContext);
-
-  const url = `${config.api_v2}runs/${accession}`;
-
-  return useApiData<RunDetail>({
-    url,
-  });
+  return useMgnifyResourceDetail<RunDetail>('runs', accession);
 };
 
 export default useRunDetail;

--- a/src/hooks/data/useSampleDetail/index.tsx
+++ b/src/hooks/data/useSampleDetail/index.tsx
@@ -1,17 +1,8 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { SampleDetail } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
+import useMgnifyResourceDetail from 'hooks/data/useMgnifyResourceDetail';
 
 const useSampleDetail = (accession: string) => {
-  const { config } = useContext(UserContext);
-
-  const url = `${config.api_v2}samples/${accession}`;
-
-  return useApiData<SampleDetail>({
-    url,
-  });
+  return useMgnifyResourceDetail<SampleDetail>('samples', accession);
 };
 
 export default useSampleDetail;

--- a/src/hooks/data/useSamples/index.tsx
+++ b/src/hooks/data/useSamples/index.tsx
@@ -1,25 +1,9 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { SampleList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useSamplesList = (parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}samples/${queryString ? `?${queryString}` : ''}`;
-
-  return useApiData<SampleList>({
-    url,
-  });
+  return useMgnifyResourceList<SampleList>('samples', parameters);
 };
 
 export default useSamplesList;

--- a/src/hooks/data/useStudies/index.tsx
+++ b/src/hooks/data/useStudies/index.tsx
@@ -1,25 +1,9 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { StudyList } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useStudiesList = (parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}studies/${queryString ? `?${queryString}` : ''}`;
-
-  return useApiData<StudyList>({
-    url,
-  });
+  return useMgnifyResourceList<StudyList>('studies', parameters);
 };
 
 export default useStudiesList;

--- a/src/hooks/data/useStudyAnalyses/index.tsx
+++ b/src/hooks/data/useStudyAnalyses/index.tsx
@@ -1,37 +1,12 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { AnalysisList } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useStudyAnalysesList = (accession: string, parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .filter(
-      ([, value]) => value !== undefined && value !== null && value !== ''
-    )
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  // const queryString = Object.entries(parameters)
-  //   .map(
-  //     ([key, value]) =>
-  //       `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-  //   )
-  //   .join('&');
-
-  const url = `${config.api_v2}studies/${accession}/analyses/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<AnalysisList>({
-    url,
-  });
+  return useMgnifyResourceList<AnalysisList>(
+    `studies/${accession}/analyses`,
+    parameters
+  );
 };
 
 export default useStudyAnalysesList;

--- a/src/hooks/data/useStudyDetail/index.tsx
+++ b/src/hooks/data/useStudyDetail/index.tsx
@@ -1,17 +1,8 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { StudyDetail } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
+import useMgnifyResourceDetail from 'hooks/data/useMgnifyResourceDetail';
 
 const useStudyDetail = (accession: string) => {
-  const { config } = useContext(UserContext);
-
-  const url = `${config.api_v2}studies/${accession}`;
-
-  return useApiData<StudyDetail>({
-    url,
-  });
+  return useMgnifyResourceDetail<StudyDetail>('studies', accession);
 };
 
 export default useStudyDetail;

--- a/src/hooks/data/useStudyPublications/index.tsx
+++ b/src/hooks/data/useStudyPublications/index.tsx
@@ -1,30 +1,15 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { PublicationList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useStudyPublicationsList = (
   accession: string,
   parameters: KeyValue = {}
 ) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}studies/${accession}/publications/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<PublicationList>({
-    url,
-  });
+  return useMgnifyResourceList<PublicationList>(
+    `studies/${accession}/publications`,
+    parameters
+  );
 };
 
 export default useStudyPublicationsList;

--- a/src/hooks/data/useStudySamples/index.tsx
+++ b/src/hooks/data/useStudySamples/index.tsx
@@ -1,27 +1,12 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { SampleList } from '@/interfaces';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useStudySamplesList = (accession: string, parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}studies/${accession}/samples/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<SampleList>({
-    url,
-  });
+  return useMgnifyResourceList<SampleList>(
+    `studies/${accession}/samples`,
+    parameters
+  );
 };
 
 export default useStudySamplesList;

--- a/src/hooks/data/useSuperStudies/index.tsx
+++ b/src/hooks/data/useSuperStudies/index.tsx
@@ -1,27 +1,9 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { SuperStudyList } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
 import { KeyValue } from 'hooks/data/useData';
+import useMgnifyResourceList from 'hooks/data/useMgnifyResourceList';
 
 const useSuperStudiesList = (parameters: KeyValue = {}) => {
-  const { config } = useContext(UserContext);
-
-  const queryString = Object.entries(parameters)
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
-    )
-    .join('&');
-
-  const url = `${config.api_v2}super-studies/${
-    queryString ? `?${queryString}` : ''
-  }`;
-
-  return useApiData<SuperStudyList>({
-    url,
-  });
+  return useMgnifyResourceList<SuperStudyList>('super-studies', parameters);
 };
 
 export default useSuperStudiesList;

--- a/src/hooks/data/useSuperStudyDetail/index.tsx
+++ b/src/hooks/data/useSuperStudyDetail/index.tsx
@@ -1,17 +1,11 @@
-import UserContext from 'pages/Login/UserContext';
-import { useContext } from 'react';
-
 import { SuperStudyDetail } from 'interfaces/index';
-import useApiData from 'hooks/data/useApiData';
+import useMgnifyResourceDetail from 'hooks/data/useMgnifyResourceDetail';
 
 const useSuperStudyDetail = (slug: string | undefined) => {
-  const { config } = useContext(UserContext);
-
-  const url = slug && `${config.api_v2}super-studies/${slug}`;
-
-  return useApiData<SuperStudyDetail>({
-    url,
-  });
+  return useMgnifyResourceDetail<SuperStudyDetail>(
+    'super-studies',
+    slug as string
+  );
 };
 
 export default useSuperStudyDetail;

--- a/src/pages/Browse/index.tsx
+++ b/src/pages/Browse/index.tsx
@@ -6,7 +6,7 @@ import BrowseSuperStudies from 'components/Browse/SuperStudies';
 import BrowseSamples from 'components/Browse/Samples';
 import BrowsePublications from 'components/Browse/Publications';
 // import BrowseGenomes from 'components/Browse/Genomes';
-// import BrowseBiomes from 'components/Browse/Biomes';
+import BrowseBiomes from 'components/Browse/Biomes';
 import Tabs from 'components/UI/Tabs';
 import Breadcrumbs from 'components/Nav/Breadcrumbs';
 import BrowseGenomes from 'components/Browse/Genomes';
@@ -17,7 +17,7 @@ const tabs = [
   { label: 'Samples', to: '/browse/samples' },
   { label: 'Publications', to: '/browse/publications' },
   { label: 'Genomes', to: '/browse/genomes' },
-  // { label: 'Biomes', to: '/browse/biomes' },
+  { label: 'Biomes', to: '/browse/biomes' },
 ];
 
 const Browse: React.FC = () => {
@@ -46,7 +46,7 @@ const Browse: React.FC = () => {
           <Route path="samples" element={<BrowseSamples />} />
           <Route path="publications" element={<BrowsePublications />} />
           <Route path="genomes" element={<BrowseGenomes />} />
-          {/* <Route path="biomes" element={<BrowseBiomes />} /> */}
+          <Route path="biomes" element={<BrowseBiomes />} />
           <Route index element={<Navigate to="studies" replace />} />
         </Routes>
       </div>


### PR DESCRIPTION
### Pull Request: Generalize MGnify API Data Fetching Hooks

This PR refactors the data fetching layer to reduce boilerplate and improve maintainability by introducing generic hooks for MGnify API v2 resources.

#### Summary of Changes

1.  **Introduced Generic Base Hooks**:
    *   `useMgnifyResourceList`: A reusable hook for fetching paginated lists. It handles query string construction, automatic URI encoding, and filtering of `undefined` parameters.
    *   `useMgnifyResourceDetail`: A reusable hook for fetching single resources by ID or accession.

2.  **Refactored Existing Hooks**:
    Converted 15+ resource-specific hooks to use the new generic base hooks. This maintains the existing typed API for components while centralizing the underlying fetching logic. Refactored hooks include:
    *   `useStudiesList`, `useStudyDetail`, `useStudySamplesList`, `useStudyAnalysesList`, `useStudyPublicationsList`
    *   `useSamplesList`, `useSampleDetail`
    *   `useRunDetail`, `useRunAnalysesList`, `useRunAssemblies`
    *   `usePublicationsList`, `usePublicationDetail`
    *   `useBiomesList`
    *   `useSuperStudiesList`, `useSuperStudyDetail`

3.  **API Migration**:
    Updated the `BrowseBiomes` component and `useBiomesList` hook to use the MGnify API v2 (`/v2/biomes`), ensuring consistency with the `BrowseStudies` implementation.

#### Benefits

*   **DRY Codebase**: Removed significant code duplication across the `src/hooks/data/` directory.
*   **Consistency**: Centralizes how URLs and query parameters are constructed for all v2 endpoints.
*   **Type Safety**: Preserves full TypeScript support by keeping the specific wrapper hooks, ensuring components don't need to manually cast API responses.
*   **Maintainability**: Any future changes to the base API configuration or global fetching logic (e.g., error handling, headers) can now be implemented in the generic hooks rather than across dozens of files.

#### Testing Performed

*   Verified that the Biomes table correctly loads and displays data from the new v2 endpoint.
*   Sanity checked that Studies, Samples, and Detail pages still fetch and render data correctly using the refactored hooks.
*   Confirmed that query parameters (pagination, filtering, ordering) are correctly passed to the API.