### PR TITLE
Fix missing genome catalogue tabs

### DIFF
--- a/src/components/Genomes/PhyloTree/index.tsx
+++ b/src/components/Genomes/PhyloTree/index.tsx
@@ -7,10 +7,14 @@ import HierarchyNode, { Node } from 'components/UI/Hierarchy';
 import useMGnifyData from '@/hooks/data/useMGnifyData';
 import useURLAccession from '@/hooks/useURLAccession';
 
-const PhyloTree: React.FC = () => {
+interface PhyloTreeProps {
+  catalogueVersion?: string;
+}
+
+const PhyloTree: React.FC<PhyloTreeProps> = ({ catalogueVersion }) => {
   const accession = useURLAccession();
   const { data, loading, error } = useMGnifyData(
-    `genome-catalogues/${accession}/downloads/phylo_tree.json`
+    `genome-catalogues/${accession}/${catalogueVersion}/downloads/phylo_tree.json`
   );
   if (loading) return <Loading size="large" />;
   if (error) return <FetchError error={error} />;

--- a/src/interfaces/index.tsx
+++ b/src/interfaces/index.tsx
@@ -150,7 +150,7 @@ export interface GenomeCatalogue extends Record<string, unknown> {
   pipeline_version_tag: string;
   catalogue_biome_label: string;
   catalogue_type: 'prokaryotes' | 'eukaryotes' | 'viruses' | string;
-  other_stats: KeyValue | unknown;
+  other_stats: KeyValue;
   biome: Biome;
 }
 

--- a/src/pages/GenomeCatalogue/index.tsx
+++ b/src/pages/GenomeCatalogue/index.tsx
@@ -16,13 +16,14 @@ import UserContext from 'pages/Login/UserContext';
 import ExtLink from 'components/UI/ExtLink';
 import Breadcrumbs from 'components/Nav/Breadcrumbs';
 import { GenomeCatalogue } from '@/interfaces';
+import PhyloTree from 'components/Genomes/PhyloTree';
 
 const tabs = [
   { label: 'Genome list', to: '#' },
   // TODO: put back when phylo tree json downloads is made available
   // { label: 'Taxonomy tree', to: '#phylo-tab' },
   // TODO: put back when protein catalogue info is made available
-  // { label: 'Protein catalogue', to: '#protein-catalog-tab' },
+  { label: 'Protein catalogue', to: '#protein-catalog-tab' },
   { label: 'Search by Gene', to: '#genome-search-tab' },
   { label: 'Search by MAG', to: '#genome-search-mag-tab' },
 ];
@@ -131,10 +132,8 @@ const GenomePage: React.FC = () => {
           <RouteForHash hash="#protein-catalog-tab">
             <h3>{genomeCatalogueData.protein_catalogue_name as string}</h3>
             <ReactMarkdown>
-              {
-                (genomeCatalogueData.protein_catalogue_description ||
-                  '') as string
-              }
+              {(genomeCatalogueData.protein_catalogue_description as string) ||
+                'No protein catalogue description available for this catalogue.'}
             </ReactMarkdown>
           </RouteForHash>
         </div>

--- a/src/pages/GenomeCatalogue/index.tsx
+++ b/src/pages/GenomeCatalogue/index.tsx
@@ -7,7 +7,6 @@ import Loading from 'components/UI/Loading';
 import FetchError from 'components/UI/FetchError';
 import Tabs from 'components/UI/Tabs';
 import GenomesTable from 'components/Genomes/Table';
-// import PhyloTree from 'components/Genomes/PhyloTree';
 import CobsSearch from 'components/Genomes/Cobs';
 import SourmashSearch from 'components/Genomes/Sourmash';
 import RouteForHash from 'components/Nav/RouteForHash';
@@ -20,9 +19,7 @@ import PhyloTree from 'components/Genomes/PhyloTree';
 
 const tabs = [
   { label: 'Genome list', to: '#' },
-  // TODO: put back when phylo tree json downloads is made available
-  // { label: 'Taxonomy tree', to: '#phylo-tab' },
-  // TODO: put back when protein catalogue info is made available
+  { label: 'Taxonomy tree', to: '#phylo-tab' },
   { label: 'Protein catalogue', to: '#protein-catalog-tab' },
   { label: 'Search by Gene', to: '#genome-search-tab' },
   { label: 'Search by MAG', to: '#genome-search-mag-tab' },
@@ -37,33 +34,41 @@ const GenomePage: React.FC = () => {
   if (loading) return <Loading size="large" />;
   if (error) return <FetchError error={error} />;
   if (!data) return <Loading />;
-  const genomeCatalogueData = data as GenomeCatalogue;
+  const {
+    catalogue_id,
+    description,
+    ftp_url,
+    genome_count,
+    name,
+    other_stats,
+    pipeline_version_tag,
+    protein_catalogue_description,
+    protein_catalogue_name,
+    unclustered_genome_count,
+    version,
+  } = data as GenomeCatalogue;
   const breadcrumbs = [
     { label: 'Home', url: '/' },
     { label: 'Genomes', url: '/browse/genomes' },
-    { label: genomeCatalogueData.name as string },
+    { label: name as string },
   ];
   return (
     <section className="vf-content">
       <Breadcrumbs links={breadcrumbs} />
-      <h2>{genomeCatalogueData.name}</h2>
+      <h2>{name}</h2>
 
       <section className="vf-card-container vf-card-container__col-4">
         <div className="vf-card-container__inner">
           <article className="vf-card vf-card--brand vf-card--bordered">
             <div className="vf-card__content | vf-stack vf-stack--200">
-              <h3 className="vf-card__heading">
-                {genomeCatalogueData.unclustered_genome_count}
-              </h3>
+              <h3 className="vf-card__heading">{unclustered_genome_count}</h3>
               <p className="vf-card__subheading">Total genomes</p>
             </div>
           </article>
 
           <article className="vf-card vf-card--brand vf-card--bordered">
             <div className="vf-card__content | vf-stack vf-stack--200">
-              <h3 className="vf-card__heading">
-                {genomeCatalogueData.genome_count}
-              </h3>
+              <h3 className="vf-card__heading">{genome_count}</h3>
               <p className="vf-card__subheading">Species-level clusters</p>
             </div>
           </article>
@@ -71,14 +76,42 @@ const GenomePage: React.FC = () => {
           <article className="vf-card vf-card--brand vf-card--bordered">
             <div className="vf-card__content | vf-stack vf-stack--200">
               <h3 className="vf-card__heading">
-                <a
-                  href={
-                    (genomeCatalogueData.ftp_url +
-                      genomeCatalogueData.catalogue_id +
-                      '/v' +
-                      genomeCatalogueData.version) as string
-                  }
-                >
+                {parseInt(
+                  other_stats['Total proteins'] as string
+                ).toLocaleString()}
+              </h3>
+              <p className="vf-card__subheading">Total proteins</p>
+            </div>
+          </article>
+
+          <article className="vf-card vf-card--brand vf-card--bordered">
+            <div className="vf-card__content | vf-stack vf-stack--200">
+              <h3 className="vf-card__heading">
+                {parseInt(
+                  other_stats['Clusters with pan-genomes'] as string
+                ).toLocaleString()}
+              </h3>
+              <p className="vf-card__subheading">Clusters with pan-genomes </p>
+            </div>
+          </article>
+
+          <article className="vf-card vf-card--brand vf-card--bordered">
+            <div className="vf-card__content | vf-stack vf-stack--200">
+              <h3 className="vf-card__heading">
+                {parseInt(
+                  other_stats['Clusters with isolate genomes'] as string
+                ).toLocaleString()}
+              </h3>
+              <p className="vf-card__subheading">
+                Clusters with isolate genomes{' '}
+              </p>
+            </div>
+          </article>
+
+          <article className="vf-card vf-card--brand vf-card--bordered">
+            <div className="vf-card__content | vf-stack vf-stack--200">
+              <h3 className="vf-card__heading">
+                <a href={(ftp_url + catalogue_id + '/v' + version) as string}>
                   FTP Site
                   <ArrowForLink />
                 </a>
@@ -91,9 +124,9 @@ const GenomePage: React.FC = () => {
             <div className="vf-card__content | vf-stack vf-stack--200">
               <h3 className="vf-card__heading">
                 <ExtLink
-                  href={`${config.magsPipelineRepo}/releases/tag/${genomeCatalogueData.pipeline_version_tag}`}
+                  href={`${config.magsPipelineRepo}/releases/tag/${pipeline_version_tag}`}
                 >
-                  Pipeline {genomeCatalogueData.pipeline_version_tag}
+                  Pipeline {pipeline_version_tag}
                 </ExtLink>
               </h3>
               <p className="vf-card__subheading">View workflow & tools</p>
@@ -103,9 +136,7 @@ const GenomePage: React.FC = () => {
       </section>
 
       <div>
-        <ReactMarkdown>
-          {genomeCatalogueData.description as string}
-        </ReactMarkdown>
+        <ReactMarkdown>{description as string}</ReactMarkdown>
       </div>
 
       <Tabs tabs={tabs} />
@@ -114,25 +145,25 @@ const GenomePage: React.FC = () => {
           <RouteForHash hash="" isDefault>
             <GenomesTable />
           </RouteForHash>
-          {/*<RouteForHash hash="#phylo-tab">*/}
-          {/*  <PhyloTree />*/}
-          {/*</RouteForHash>*/}
+          <RouteForHash hash="#phylo-tab">
+            <PhyloTree catalogueVersion={version} />
+          </RouteForHash>
           <RouteForHash hash="#genome-search-tab">
             <CobsSearch
-              catalogueName={genomeCatalogueData.name as string}
-              catalogueID={genomeCatalogueData.catalogue_id}
+              catalogueName={name as string}
+              catalogueID={catalogue_id}
             />
           </RouteForHash>
           <RouteForHash hash="#genome-search-mag-tab">
             <SourmashSearch
-              catalogueName={genomeCatalogueData.name as string}
-              catalogueID={genomeCatalogueData.catalogue_id}
+              catalogueName={name as string}
+              catalogueID={catalogue_id}
             />
           </RouteForHash>
           <RouteForHash hash="#protein-catalog-tab">
-            <h3>{genomeCatalogueData.protein_catalogue_name as string}</h3>
+            <h3>{protein_catalogue_name as string}</h3>
             <ReactMarkdown>
-              {(genomeCatalogueData.protein_catalogue_description as string) ||
+              {(protein_catalogue_description as string) ||
                 'No protein catalogue description available for this catalogue.'}
             </ReactMarkdown>
           </RouteForHash>


### PR DESCRIPTION
This pull request addresses : 
https://embl.atlassian.net/browse/EMG-9809
and https://embl.atlassian.net/browse/EMG-9808

It adds the missing stats cards on https://www.ebi.ac.uk/metagenomics/genome-catalogues/barley-rhizosphere-v2-0.
It also adjusts the <PhyloTree/> component to use the newly exposed download objects on the v2 catalogue detail endpoint, to render the taxonomy tree tab. 
It also brings back the Protein catalogue tab.