### PR TITLE
Playwright

### DIFF
--- a/.ai/mcp/mcp.json
+++ b/.ai/mcp/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -1,0 +1,38 @@
+name: Playwright Screenshots
+
+on:
+  workflow_dispatch:
+
+jobs:
+  screenshots:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: ⚙️ - Settings
+        run: |
+          echo "{\"api\": \"https://www.ebi.ac.uk/metagenomics/api/v1/\", \"api_v2\": \"https://www.ebi.ac.uk/metagenomics/api/v2/\"}" > config.private.json
+
+      - name: 📜 - Set up JS Node 23
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🔧 - Install dependencies
+        run: npm ci
+
+      - name: 🎭 - Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: 🧪 - Run Playwright tests
+        run: npm run screenshots
+
+      - name: 📸 - Upload Screenshots
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: analysis-screenshots
+          path: screenshots/
+          retention-days: 30

--- a/.github/workflows/playwright-screenshots.yml
+++ b/.github/workflows/playwright-screenshots.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           echo "{\"api\": \"https://www.ebi.ac.uk/metagenomics/api/v1/\", \"api_v2\": \"https://www.ebi.ac.uk/metagenomics/api/v2/\"}" > config.private.json
 
-      - name: 📜 - Set up JS Node 23
+      - name: 📜 - Set up JS Node 24
         uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ config.private.json
 /npm-debug.log
 
 public/mgnify-sourmash-component
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/
+screenshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,8 @@
         "@cypress/code-coverage": "3.12.1",
         "@eslint/js": "^9.33.0",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
+        "@playwright/mcp": "^0.0.75",
+        "@playwright/test": "^1.60.0",
         "@sentry/webpack-plugin": "^1.19.1",
         "@types/flat": "^5.0.5",
         "@types/google.maps": "3.47.2",
@@ -4517,6 +4519,86 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.75.tgz",
+      "integrity": "sha512-oBjzVXfEGZ9Ev45tKKQULNDVdF83B82lg0uPejEK3xsp/zWmdNdNVnPi032fmd/o20ZZXs+LX7cr77qRNbV4VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0-alpha-1778188671000",
+        "playwright-core": "1.61.0-alpha-1778188671000"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/playwright": {
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0-alpha-1778188671000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/mcp/node_modules/playwright-core": {
+      "version": "1.61.0-alpha-1778188671000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0-alpha-1778188671000.tgz",
+      "integrity": "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@plotly/d3": {
@@ -17565,6 +17647,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plotly.js": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "vite:preview": "vite preview",
     "eslint": "eslint src",
     "eslint:fix": "eslint src --fix",
+    "screenshots": "playwright test tests/analysis-screenshots.spec.ts",
+    "mcp-playwright": "playwright-mcp",
     "prettier": "prettier --write .",
     "prepare": "husky install",
     "postinstall": "node scripts/copy-mgnify-sourmash-component-assets.mjs"
@@ -94,6 +96,8 @@
     "@cypress/code-coverage": "3.12.1",
     "@eslint/js": "^9.33.0",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
+    "@playwright/mcp": "^0.0.75",
+    "@playwright/test": "^1.60.0",
     "@sentry/webpack-plugin": "^1.19.1",
     "@types/flat": "^5.0.5",
     "@types/google.maps": "3.47.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 120000,
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    baseURL: 'http://localhost:9000/metagenomics/',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:9000/metagenomics/',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/analysis-screenshots.spec.ts
+++ b/tests/analysis-screenshots.spec.ts
@@ -1,0 +1,119 @@
+import { test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const analyses = [
+  { accession: 'MGYA01022581', version: '6', type: 'assembly' },
+  { accession: 'MGYA01020458', version: '6', type: 'metagenomic' },
+  { accession: 'MGYA01021240', version: '6', type: 'amplicon' },
+  { accession: 'MGYA00589025', version: '5', type: 'assembly' },
+  { accession: 'MGYA00795052', version: '5', type: 'metagenomics' },
+  { accession: 'MGYA00429313', version: '5', type: 'amplicon' },
+  { accession: 'MGYA00345682', version: '4.1', type: 'assembly' },
+  { accession: 'MGYA00581843', version: '4.1', type: 'metagenomic' },
+  { accession: 'MGYA00160062', version: '4.1', type: 'amplicon' },
+  { accession: 'MGYA00139323', version: '4', type: 'assembly' },
+  { accession: 'MGYA00135058', version: '4', type: 'metagenomic' },
+  { accession: 'MGYA00135048', version: '4', type: 'amplicon' },
+  { accession: 'MGYA00132146', version: '3', type: 'assembly' },
+  { accession: 'MGYA00142024', version: '3', type: 'metagenomic' },
+  { accession: 'MGYA00138745', version: '3', type: 'amplicon' },
+  { accession: 'MGYA00005112', version: '2', type: 'metagenomic' },
+  { accession: 'MGYA00013658', version: '2', type: 'amplicon' },
+  { accession: 'MGYA00004369', version: '1', type: 'assembly' },
+  { accession: 'MGYA00002634', version: '1', type: 'metagenomic' },
+  { accession: 'MGYA00002792', version: '1', type: 'amplicon' },
+];
+
+for (const { accession, version, type } of analyses) {
+  test(`take screenshots for ${accession} (v${version} ${type})`, async ({
+    page,
+  }) => {
+    const relativeUrl = `v2-analyses/${accession}`;
+
+    // Create screenshots directory if it doesn't exist
+    const dirName = `v${version}_${type}_${accession}`;
+    const screenshotDir = path.join(__dirname, '..', 'screenshots', dirName);
+    if (!fs.existsSync(screenshotDir)) {
+      fs.mkdirSync(screenshotDir, { recursive: true });
+    }
+
+    // Set cookie to accept cookies and avoid the banner
+    await page.context().addCookies([
+      {
+        name: 'cookies-accepted',
+        value: 'true',
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+
+    await page.goto(`${relativeUrl}/overview`);
+
+    // Wait for tabs to be visible
+    await page.waitForSelector('.vf-tabs__list');
+
+    // Get all tab links
+    const tabLinks = page.locator('.vf-tabs__link');
+    const count = await tabLinks.count();
+    console.log(`Found ${count} tabs for ${accession}.`);
+
+    const tabNames: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const name = await tabLinks.nth(i).innerText();
+      tabNames.push(
+        name
+          .trim()
+          .replace(/\//g, '_')
+          .replace(/\s+/g, '_')
+          .toLowerCase()
+      );
+    }
+
+    for (let i = 0; i < count; i++) {
+      const tabName = tabNames[i];
+      console.log(`Processing tab: ${tabName} for ${accession}`);
+
+      await tabLinks.nth(i).click();
+
+      // Wait for some content to load or just wait a bit for animations
+      // Using a combination of timeout and waiting for network idle if possible
+      await page.waitForTimeout(3000);
+
+      // Take screenshot
+      await page.screenshot({
+        path: path.join(screenshotDir, `${tabName}.png`),
+        fullPage: true,
+      });
+
+      // Check for subtabs (buttons with mg-button-as-tab class)
+      const subtabButtons = page.locator('.mg-button-as-tab');
+      const subtabCount = await subtabButtons.count();
+      if (subtabCount > 0) {
+        console.log(`Found ${subtabCount} subtabs for ${tabName}`);
+        const subtabNames: string[] = [];
+        for (let j = 0; j < subtabCount; j++) {
+          const name = await subtabButtons.nth(j).innerText();
+          subtabNames.push(
+            name
+              .trim()
+              .replace(/\//g, '_')
+              .replace(/\s+/g, '_')
+              .toLowerCase()
+          );
+        }
+
+        for (let j = 0; j < subtabCount; j++) {
+          const subtabName = subtabNames[j];
+          console.log(`Processing subtab: ${subtabName} for ${tabName}`);
+          await subtabButtons.nth(j).click();
+          await page.waitForTimeout(2000);
+          await page.screenshot({
+            path: path.join(screenshotDir, `${tabName}_${subtabName}.png`),
+            fullPage: true,
+          });
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
This PR:
- adds Playwright
  - I am thinking we could migrate from Cypress to Playwright, this PR just adds it alongside
  - the main benefit is the nice MCP Playwright has (configured in this PR) to that Junie/Claude et al can interact with the running site directly when debugging/adding components etc. I found this to work very well. 
    - I expect it to also be very useful in having llm-assisted test writing, as we have historically struggled to keep Cypress tests up to date and high-coverage.
  - I also added a script + action to take screenshots of known "canary" MGYA pages for various pipeline versions and experiment types. This is handy to audit whether the various tabs are showing the right thing across all versions. Junie authored this using the MCP, for example.