### PR TITLE
Multiple Krona plot support on WGS

### DIFF
--- a/src/components/Analysis/WGSTaxonomy/index.tsx
+++ b/src/components/Analysis/WGSTaxonomy/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import DetailedVisualisationCard from 'components/Analysis/VisualisationCards/DetailedVisualisationCard';
 import 'components/Analysis/AmpliconTaxonomy/style.css';
 import AnalysisContext from 'pages/Analysis/V2AnalysisContext';
@@ -8,12 +8,20 @@ import KronaIframe from 'components/UI/KronaIframe';
 
 const WGSTaxonomy: React.FC = () => {
   const { overviewData: analysisData } = useContext(AnalysisContext);
-  const kronaFile = analysisData?.downloads.find(
-    (file: Download) =>
-      file.download_type === 'Taxonomic analysis' && file.file_type === 'html'
+  const kronaFiles = useMemo(
+    () =>
+      analysisData?.downloads.filter(
+        (file: Download) =>
+          file.download_type === 'Taxonomic analysis' &&
+          file.file_type === 'html'
+      ) ?? [],
+    [analysisData?.downloads]
   );
+  const [selectedKronaUrl, setSelectedKronaUrl] = useState<string>();
+  const selectedKronaFile =
+    kronaFiles.find((file) => file.url === selectedKronaUrl) ?? kronaFiles[0];
 
-  if (!kronaFile)
+  if (!selectedKronaFile)
     return <InfoBanner title="No taxonomy data available" type="warning" />;
 
   return (
@@ -23,22 +31,50 @@ const WGSTaxonomy: React.FC = () => {
           Taxonomic Analysis Visualization
         </summary>
 
-        <DetailedVisualisationCard ftpLink={kronaFile.url}>
-          <div className="vf-card__content | vf-stack vf-stack--400">
-            <h3 className="vf-card__heading">Krona Taxonomy Visualization</h3>
-            <p className="vf-card__subheading">
-              Interactive taxonomic hierarchy
-            </p>
-            <p className="vf-card__text">
-              <KronaIframe
-                className="krona-iframe"
-                url={kronaFile.url}
-                height="700px"
-                title="Krona Taxonomy Visualization"
-              />
-            </p>
-          </div>
-        </DetailedVisualisationCard>
+        <div className="vf-stack vf-stack--400">
+          {kronaFiles.length > 1 && (
+            <div className="vf-tabs mg-search-tabs">
+              <ul className="vf-tabs__list" role="tablist">
+                {kronaFiles.map((file) => {
+                  const isActive = file.url === selectedKronaFile.url;
+                  return (
+                    <li className="vf-tabs__item" key={file.url}>
+                      <button
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        className={`vf-tabs__link mg-button-as-tab ${
+                          isActive ? 'is-active' : ''
+                        }`}
+                        onClick={() => setSelectedKronaUrl(file.url)}
+                      >
+                        {file.short_description}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          <DetailedVisualisationCard ftpLink={selectedKronaFile.url}>
+            <div className="vf-card__content | vf-stack vf-stack--400">
+              <h3 className="vf-card__heading">Krona Taxonomy Visualization</h3>
+              <p className="vf-card__subheading">
+                {selectedKronaFile.long_description}
+              </p>
+              <div className="vf-card__text">
+                <KronaIframe
+                  key={selectedKronaFile.url}
+                  className="krona-iframe"
+                  url={selectedKronaFile.url}
+                  height="700px"
+                  title={selectedKronaFile.short_description}
+                />
+              </div>
+            </div>
+          </DetailedVisualisationCard>
+        </div>
       </details>
 
       <div className="taxonomy-info">


### PR DESCRIPTION
Show tabs on WGS taxonomy component when there are multiple krona plots (e.g. RawR V6 analyses)