### PR TITLE
Handle ENA study accessions 

### DIFF
--- a/cypress/e2e/study.js
+++ b/cypress/e2e/study.js
@@ -54,6 +54,27 @@ describe('Study page', function() {
         });
     });
 
+    context('Canonical accession redirects', function() {
+        it('Redirects an INSDC accession to the canonical MGYS study accession', function() {
+            const insdcId = 'PRJNA398089';
+
+            cy.intercept('GET', `**/studies/${insdcId}`, {
+                statusCode: 404,
+                body: {detail: 'Not found'},
+            });
+            cy.intercept('GET', `**/studies/insdc/${insdcId}`, {
+                body: {accession: projectId},
+            }).as('getCanonicalStudyAccession');
+
+            openPage(`studies/${insdcId}/analysis`);
+
+            cy.wait('@getCanonicalStudyAccession');
+            cy.location('pathname').should('contain', `/studies/${projectId}`);
+            cy.location('pathname').should('not.contain', '/analysis');
+            waitForPageLoad(pageTitle);
+        });
+    });
+
     context.skip('Related studies', function() {
         const relatedStudiesList = '[data-cy=\'relatedStudies\']';
         it('Should display related study section', function() {

--- a/src/hooks/useCanonicalAccessionRedirect/index.tsx
+++ b/src/hooks/useCanonicalAccessionRedirect/index.tsx
@@ -1,27 +1,62 @@
 import useURLAccession from '@/hooks/useURLAccession';
-import { MGnifyResponseObj } from '@/hooks/data/useData';
+import UserContext from '@/pages/Login/UserContext';
+import axios from 'axios';
+import { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { EnaDerivedObject } from 'interfaces/index';
 
-const useCanonicalAccessionRedirect = (
-  data: MGnifyResponseObj | EnaDerivedObject
-) => {
+type CanonicalAccessionResponse = {
+  accession?: string;
+};
+
+const isMgnifyStudyAccession = (accession?: string): boolean =>
+  Boolean(accession?.startsWith('MGYS'));
+
+const useCanonicalAccessionRedirect = () => {
   const urlAccession = useURLAccession();
   const navigate = useNavigate();
+  const { config } = useContext(UserContext);
+  const [loading, setLoading] = useState(false);
 
-  if (!data) return;
-  if (!urlAccession) return;
+  useEffect(() => {
+    if (!urlAccession || isMgnifyStudyAccession(urlAccession)) {
+      setLoading(false);
+      return undefined;
+    }
 
-  const dataAccession =
-    (data as unknown as MGnifyResponseObj)?.data?.id ||
-    (data as EnaDerivedObject).accession;
+    const abortController = new AbortController();
+    const canonicalAccessionUrl = `${
+      config.api_v2
+    }studies/insdc/${encodeURIComponent(urlAccession)}`;
 
-  if (
-    dataAccession &&
-    dataAccession.toUpperCase() !== urlAccession.toUpperCase()
-  ) {
-    navigate(window.location.pathname.replace(urlAccession, dataAccession));
-  }
+    setLoading(true);
+
+    const lookupCanonicalAccession = async () => {
+      try {
+        const response = await axios.get<CanonicalAccessionResponse>(
+          canonicalAccessionUrl,
+          { signal: abortController.signal }
+        );
+        const accession = response.data.accession;
+
+        if (isMgnifyStudyAccession(accession)) {
+          navigate(`/studies/${accession}`, { replace: true });
+          return;
+        }
+      } catch {
+        if (abortController.signal.aborted) return;
+      }
+
+      setLoading(false);
+    };
+
+    lookupCanonicalAccession();
+
+    return () => {
+      abortController.abort();
+    };
+  }, [config.api_v2, navigate, urlAccession]);
+
+  return loading;
 };
 
 export default useCanonicalAccessionRedirect;

--- a/src/pages/Study/index.tsx
+++ b/src/pages/Study/index.tsx
@@ -9,7 +9,6 @@ import SummaryTab from 'components/Study/SummaryTab';
 import useCanonicalAccessionRedirect from '@/hooks/useCanonicalAccessionRedirect';
 import Breadcrumbs from 'components/Nav/Breadcrumbs';
 import useStudyDetail from 'hooks/data/useStudyDetail';
-import { EnaDerivedObject } from '@/interfaces';
 import { createSharedQueryParamContextForTable } from 'hooks/queryParamState/useQueryParamState';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
@@ -26,8 +25,8 @@ const StudyPage: React.FC = () => {
 
   const { data, loading, error } = useStudyDetail(accession || '');
 
-  useCanonicalAccessionRedirect(data as EnaDerivedObject);
-  if (loading) return <Loading size="large" />;
+  const checkingCanonicalAccession = useCanonicalAccessionRedirect();
+  if (loading || checkingCanonicalAccession) return <Loading size="large" />;
   if (error) return <FetchError error={error} />;
   if (!data) return <Loading />;
 


### PR DESCRIPTION
This PR reimplements the old (APIv1 era) logic where a page load like studies/ERPxxx would redirect to studies/MGYSxxx (using the "canonical" accession of the MGYS)

This was reimplemented on APIv2 using different logic, since APIv1 transparently handled non-canonical study accessions as pks in the database, but APIv2 does not, it requires an extra call to find the canonical accession (api/studies/insdc/{accession})

If loaded with a non-MGYS accession, that endpoint is now called and the redirect happens in the client. 