### PR TITLE
Hotfix/primer labels

### DIFF
--- a/src/components/Asv/ChimericProportions/index.tsx
+++ b/src/components/Asv/ChimericProportions/index.tsx
@@ -154,7 +154,7 @@ const ChimericProportions = ({ fileUrl }: { fileUrl: string }) => {
     <div className="space-y-6">
       <div className="vf-card__content | vf-stack vf-stack--400">
         <h3 className="vf-card__heading text-lg font-bold mb-2">
-          Amplicon Sequencing Reffffsults - {sampleId}
+          Amplicon Sequencing Results - {sampleId}
         </h3>
 
         <div className="vf-stack vf-stack--400">

--- a/src/components/Asv/index.tsx
+++ b/src/components/Asv/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import useURLAccession from 'hooks/useURLAccession';
 import Loading from 'components/UI/Loading';
@@ -8,19 +8,29 @@ import DetailedVisualisationCard from 'components/Analysis/VisualisationCards/De
 import ChimericProportions from 'components/Asv/ChimericProportions';
 import AsvDistribution from 'components/Asv/AsvDistribution';
 import PrimerIdentification from 'components/PrimerIdentification';
+import { fetchText } from 'utils/fetch';
 
-const tabs = [
+const BASE_TABS = [
   { id: 'qc-statistics', label: 'Quality Control Statistics' },
   { id: 'asv-distribution', label: 'ASV Distribution' },
-  { id: 'primer-identification', label: 'Primer Identification' },
-];
+] as const;
+
+const PRIMER_IDENTIFICATION_TAB = {
+  id: 'primer-identification',
+  label: 'Primer Identification',
+} as const;
 
 const Asv: React.FC = () => {
   const [activeTab, setActiveTab] = useState(() => {
     const { hash } = window.location;
     const tabId = hash.replace('#', '');
-    return tabs.some((t) => t.id === tabId) ? tabId : tabs[0].id;
+    return (
+      [...BASE_TABS, PRIMER_IDENTIFICATION_TAB].find((t) => t.id === tabId)
+        ?.id || BASE_TABS[0].id
+    );
   });
+  const [primerIdentificationTabStatus, setPrimerIdentificationTabStatus] =
+    useState<'checking' | 'available' | 'unavailable'>('checking');
   const accession = useURLAccession();
   const { data, loading, error } = useAnalysisDetail(accession);
   const dada2StatsFile = data?.downloads.find(
@@ -30,11 +40,76 @@ const Asv: React.FC = () => {
     (file) =>
       file.download_group === 'asv.distribution' && file.file_type === 'tsv'
   );
+  const primerIdentificationFile = data?.downloads.find(
+    (file) =>
+      file.download_group === 'primer_identification' &&
+      file.file_type === 'tsv'
+  );
+  const shouldShowPrimerTab =
+    primerIdentificationTabStatus === 'available' ||
+    (primerIdentificationTabStatus === 'checking' &&
+      activeTab === PRIMER_IDENTIFICATION_TAB.id &&
+      Boolean(primerIdentificationFile?.url));
+  const tabs = shouldShowPrimerTab
+    ? [...BASE_TABS, PRIMER_IDENTIFICATION_TAB]
+    : [...BASE_TABS];
+  const activeTabIsAvailable = tabs.some((tab) => tab.id === activeTab);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    if (!primerIdentificationFile?.url) {
+      setPrimerIdentificationTabStatus('unavailable');
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    setPrimerIdentificationTabStatus('checking');
+
+    fetchText(
+      primerIdentificationFile.url,
+      {},
+      'The primer data file is empty or missing.'
+    )
+      .then((tsvText) => {
+        const lines = tsvText.trim().split('\n');
+        const hasPrimerRows = lines.length >= 2;
+
+        if (!isCancelled) {
+          setPrimerIdentificationTabStatus(
+            hasPrimerRows ? 'available' : 'unavailable'
+          );
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setPrimerIdentificationTabStatus('unavailable');
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [primerIdentificationFile]);
+
+  useEffect(() => {
+    if (!activeTabIsAvailable) {
+      const fallbackTab = BASE_TABS[0].id;
+      setActiveTab(fallbackTab);
+      const { pathname, search } = window.location;
+      const cleanPathname = pathname.endsWith('/') ? pathname : `${pathname}/`;
+      window.history.replaceState(
+        null,
+        '',
+        `${cleanPathname}${search}#${fallbackTab}`
+      );
+    }
+  }, [activeTab, activeTabIsAvailable]);
 
   if (loading) return <Loading size="large" />;
   if (error) return <FetchError error={error} />;
   if (!data) return <Loading />;
-
 
   const handleTabClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
@@ -47,7 +122,7 @@ const Asv: React.FC = () => {
     window.history.pushState(null, '', `${cleanPathname}${search}#${tabId}`);
   };
 
-  const getSepcificFile = (group: string, type: string) => {
+  const getSpecificDownloadsFile = (group: string, type: string) => {
     return data?.downloads.find(
       (file) => file.download_group === group && file.file_type === type
     );
@@ -125,21 +200,26 @@ const Asv: React.FC = () => {
           )}
         </section>
 
-        <section
-          className="vf-tabs__section"
-          id="primer-identification"
-          role="tabpanel"
-          aria-labelledby="primer-identification"
-          style={{
-            display: activeTab === 'primer-identification' ? 'block' : 'none',
-          }}
-        >
-          <PrimerIdentification
-            infoText="Primers are short sequences of nucleic acid that provide a starting point for DNA synthesis.
+        {primerIdentificationTabStatus === 'available' && (
+          <section
+            className="vf-tabs__section"
+            id="primer-identification"
+            role="tabpanel"
+            aria-labelledby="primer-identification"
+            style={{
+              display: activeTab === 'primer-identification' ? 'block' : 'none',
+            }}
+          >
+            <PrimerIdentification
+              infoText="Primers are short sequences of nucleic acid that provide a starting point for DNA synthesis.
             In 16S rRNA analysis, they target specific variable regions of the gene."
-            downloadableFile={getSepcificFile('primer_identification', 'tsv')}
-          />
-        </section>
+              downloadableFile={getSpecificDownloadsFile(
+                'primer_identification',
+                'tsv'
+              )}
+            />
+          </section>
+        )}
       </div>
     </section>
   );

--- a/src/components/PrimerIdentification/index.tsx
+++ b/src/components/PrimerIdentification/index.tsx
@@ -39,11 +39,13 @@ interface PrimerData {
 interface PrimerValidationDisplayProps {
   downloadableFile?: Download;
   infoText?: string;
+  onEmpty?: () => void;
 }
 
 const PrimerValidationDisplay: React.FC<PrimerValidationDisplayProps> = ({
   downloadableFile,
   infoText,
+  onEmpty,
 }) => {
   const [data, setData] = useState<PrimerData>();
   const [loading, setLoading] = useState(true);
@@ -54,6 +56,7 @@ const PrimerValidationDisplay: React.FC<PrimerValidationDisplayProps> = ({
   useEffect(() => {
     if (!downloadableFile?.url) {
       setLoading(false);
+      if (onEmpty) onEmpty();
       return;
     }
 
@@ -65,6 +68,7 @@ const PrimerValidationDisplay: React.FC<PrimerValidationDisplayProps> = ({
       .then((tsvText) => {
         const lines = tsvText.trim().split('\n');
         if (lines.length < 2) {
+          if (onEmpty) onEmpty();
           throw new Error('No primer data available');
         }
         const headers = lines[0].split('\t');
@@ -78,8 +82,9 @@ const PrimerValidationDisplay: React.FC<PrimerValidationDisplayProps> = ({
 
         const primers: Primer[] = rows.map((row) => ({
           name: row.PrimerName,
-          identification_strategy:
-            row.AssertionMethod === 'automatic assertion' ? 'auto' : 'std',
+          identification_strategy: row.PrimerName.endsWith('_auto')
+            ? 'auto'
+            : 'std',
           region: row.VariableRegion,
           sequence: row.PrimerSeq,
           strand: row.PrimerStrand,


### PR DESCRIPTION
<img width="1269" height="586" alt="Screenshot 2026-06-26 at 09 47 45" src="https://github.com/user-attachments/assets/7c39833c-f423-4690-81a2-086bee8363c2" />
<img width="1301" height="579" alt="Screenshot 2026-06-26 at 09 47 51" src="https://github.com/user-attachments/assets/58bcf2a6-f1da-46d3-8fab-5b86000c603a" />

Primer identification strategy labels (Std or auto)  were previously being derived from the AssertionMethod value: 

`
row.AssertionMethod === 'automatic assertion' ? 'auto' : 'std',
`
Discussions with @chrisAta revealed that we should be using the PrimerName value instead, and checking for values that end with _auto. 

This PR addresses this problem. 