### PR TITLE
Trust database for all legacy files

### DIFF
--- a/src/hooks/data/useLegacyAnalysisKnownFiles/index.tsx
+++ b/src/hooks/data/useLegacyAnalysisKnownFiles/index.tsx
@@ -1,25 +1,26 @@
 import { useContext, useMemo } from 'react';
 import AnalysisContext from 'pages/Analysis/V2AnalysisContext';
+import type { Download } from '@/interfaces';
+
+const urlsForAliases = (downloads: Download[], aliases: string[]) =>
+  aliases
+    .map((alias) => downloads.find((download) => download.alias === alias)?.url)
+    .filter(Boolean) as string[];
 
 const useLegacyAnalysisKnownFiles = () => {
-  // This hook provides data file paths for "known" files output by v4.1 and v5 MGnify analysis pipelines.
-  // This is mostly for files that aren't (always) present in the downloads lists of the analyses from APIv2.
+  // This hook provides data file URLs for "known" files output by v4.1 and v5 MGnify analysis pipelines.
   // This hook lets the analysis page components show the data files / data visualisations for these files
   // which previously were served from either a database backend or from custom file-readers on the API side.
-  // TODO: ideally every case would be covered by an entry in the analysis object's downloads list.
   const { overviewData: analysisData } = useContext(AnalysisContext);
   const resultsDir = analysisData?.results_dir;
   const pipelineVersion = analysisData?.pipeline_version;
-  const experimentType = analysisData?.experiment_type;
 
   const isVersion41 = pipelineVersion === 'V4.1';
   const isVersion50 = pipelineVersion === 'V5' || pipelineVersion === '5.0';
   const isSupportedVersion = isVersion41 || isVersion50;
 
-  const isAssembly = experimentType?.toLowerCase().endsWith('assembly');
-
   return useMemo(() => {
-    if (!resultsDir || !isSupportedVersion) {
+    if (!isSupportedVersion) {
       return {
         isSupportedVersion,
         resultsDir,
@@ -27,113 +28,80 @@ const useLegacyAnalysisKnownFiles = () => {
       };
     }
 
-    const summaryPath = `${resultsDir}/qc-statistics/summary.out`;
-    const qcStepPath = isVersion41
-      ? `${resultsDir}/qc-statistics/summary.out`
-      : `${resultsDir}/qc_summary`;
+    const downloads = analysisData?.downloads || [];
+    const qcDownloads = downloads.filter(
+      (download) => download.download_group === 'quality_control'
+    );
+    const qcUrlsForAliases = (aliases: string[]) =>
+      urlsForAliases(qcDownloads, aliases);
 
-    const seqLengthPath = `${resultsDir}/qc-statistics/seq-length.out`;
-    const seqLengthFallbacks = [
-      `${resultsDir}/qc-statistics/seq-length.out.full`,
-      `${resultsDir}/qc-statistics/seq-length.out.sub-set`,
-      `${resultsDir}/seq-length.out`,
-      `${resultsDir}/seq-length.out.full`,
-      `${resultsDir}/seq-length.out.sub-set`,
-    ];
-    const gcDistributionPath = `${resultsDir}/qc-statistics/GC-distribution.out`;
-    const gcDistributionFallbacks = [
-      `${resultsDir}/qc-statistics/GC-distribution.out.full`,
-      `${resultsDir}/qc-statistics/GC-distribution.out.sub-set`,
-      `${resultsDir}/GC-distribution.out`,
-      `${resultsDir}/GC-distribution.out.full`,
-      `${resultsDir}/GC-distribution.out.sub-set`,
-    ];
-    const nucleotideDistributionPath = `${resultsDir}/qc-statistics/nucleotide-distribution.out`;
-    const nucleotideDistributionFallbacks = [
-      `${resultsDir}/qc-statistics/nucleotide-distribution.out.full`,
-      `${resultsDir}/qc-statistics/nucleotide-distribution.out.sub-set`,
-      `${resultsDir}/nucleotide-distribution.out`,
-      `${resultsDir}/nucleotide-distribution.out.full`,
-      `${resultsDir}/nucleotide-distribution.out.sub-set`,
-    ];
+    const [summaryPath = ''] = qcUrlsForAliases(['qc-statistics/summary.out']);
+    const [qcStepPath = ''] = isVersion41
+      ? [summaryPath]
+      : qcUrlsForAliases(['qc_summary']);
 
-    const taxonomyPaths: Record<
-      string,
-      { krona: string; tsv: string; txt: string }
-    > = {};
-    const detectedMarkers = new Set<string>();
+    const [seqLengthPath = '', ...seqLengthFallbacks] = qcUrlsForAliases([
+      'qc-statistics/seq-length.out',
+      'qc-statistics/seq-length.out.full',
+      'qc-statistics/seq-length.out.sub-set',
+      'seq-length.out',
+      'seq-length.out.full',
+      'seq-length.out.sub-set',
+    ]);
+    const [gcDistributionPath = '', ...gcDistributionFallbacks] =
+      qcUrlsForAliases([
+        'qc-statistics/GC-distribution.out',
+        'qc-statistics/GC-distribution.out.full',
+        'qc-statistics/GC-distribution.out.sub-set',
+        'GC-distribution.out',
+        'GC-distribution.out.full',
+        'GC-distribution.out.sub-set',
+      ]);
+    const [
+      nucleotideDistributionPath = '',
+      ...nucleotideDistributionFallbacks
+    ] = qcUrlsForAliases([
+      'qc-statistics/nucleotide-distribution.out',
+      'qc-statistics/nucleotide-distribution.out.full',
+      'qc-statistics/nucleotide-distribution.out.sub-set',
+      'nucleotide-distribution.out',
+      'nucleotide-distribution.out.full',
+      'nucleotide-distribution.out.sub-set',
+    ]);
 
-    (analysisData?.downloads || []).forEach((download) => {
-      const isTaxonomic =
-        download.download_group === 'taxonomic_analysis' ||
-        download.download_type === 'Taxonomic analysis';
-
-      if (!isTaxonomic) return;
-
-      // Example alias: "SSU rRNA KRONA plot" or "SSU rRNA taxonomic classification"
-      const alias = download.alias.toLowerCase();
-      const marker = ['ssu', 'lsu', 'itsonedb', 'unite'].find((m) =>
-        alias.includes(m)
+    const taxonomyPaths = downloads
+      .filter((download) =>
+        download.download_group.startsWith('taxonomies.closed_reference.')
+      )
+      .reduce<Record<string, { krona: string; tsv: string; txt: string }>>(
+        (paths, download) => {
+          const marker = download.download_group.split('.').at(-1);
+          if (!marker) return paths;
+          if (!paths[marker]) {
+            paths[marker] = { krona: '', tsv: '', txt: '' };
+          }
+          if (download.alias.endsWith('/krona.html')) {
+            paths[marker].krona = download.url;
+          } else if (download.alias.endsWith('.txt')) {
+            paths[marker].txt = download.url;
+          } else if (download.alias.endsWith('.tsv')) {
+            paths[marker].tsv = download.url;
+          }
+          return paths;
+        },
+        {}
       );
 
-      if (!marker) return;
-
-      detectedMarkers.add(marker);
-      if (!taxonomyPaths[marker]) {
-        taxonomyPaths[marker] = {
-          krona: `${resultsDir}/taxonomy-summary/${marker.toUpperCase()}/krona.html`,
-          tsv: '',
-          txt: '',
-        };
-      }
-
-      const isGzipped = download.url.endsWith('.gz');
-
-      if (download.file_type === 'html' && alias.includes('krona')) {
-        taxonomyPaths[marker].krona = download.url;
-      } else if (download.file_type === 'tsv' && !isGzipped) {
-        taxonomyPaths[marker].tsv = download.url;
-      } else if (download.file_type === 'txt' && !isGzipped) {
-        taxonomyPaths[marker].txt = download.url;
-      } else if (download.file_type === 'biom' && !taxonomyPaths[marker].tsv) {
-        // Some analyses might have .biom but we need the .tsv for the table.
-        // We can predict the .tsv path from the .biom path usually.
-        taxonomyPaths[marker].tsv = download.url.replace('.biom', '.tsv');
-      }
-    });
-
-    // Fallback: If no markers were detected via downloads, but it's a supported version,
-    // we assume SSU and LSU might exist in the standard locations.
-    const mayHaveUnindexedSsuOrLsuFiles =
-      detectedMarkers.size === 0 && isSupportedVersion;
-    if (mayHaveUnindexedSsuOrLsuFiles) {
-      ['ssu', 'lsu'].forEach((marker) => {
-        taxonomyPaths[marker] = {
-          krona: `${resultsDir}/taxonomy-summary/${marker.toUpperCase()}/krona.html`,
-          tsv: `${resultsDir}/taxonomy-summary/${marker.toUpperCase()}/${
-            analysisData.accession
-          }_${marker.toUpperCase()}.fasta.mseq.tsv`,
-          txt: `${resultsDir}/taxonomy-summary/${marker.toUpperCase()}/${
-            analysisData.accession
-          }_${marker.toUpperCase()}.fasta.mseq.txt`,
-        };
-      });
-    }
-
-    const functionalAccession = analysisData.assembly?.accession;
-    const functionalFilename =
-      isAssembly && functionalAccession
-        ? `${functionalAccession}_FASTA`
-        : functionalAccession;
-
     const interproPath =
-      isVersion41 && functionalFilename
-        ? `${resultsDir}/${functionalFilename}_summary.ipr`
-        : '';
+      downloads.find(
+        (download) =>
+          download.download_group === 'functional_annotation.interpro'
+      )?.url || '';
     const goPath =
-      isVersion41 && functionalFilename
-        ? `${resultsDir}/${functionalFilename}_summary.go`
-        : '';
+      downloads.find(
+        (download) =>
+          download.download_group === 'functional_annotation.go_slims'
+      )?.url || '';
 
     return {
       isSupportedVersion,
@@ -156,9 +124,6 @@ const useLegacyAnalysisKnownFiles = () => {
     isSupportedVersion,
     isVersion41,
     analysisData?.downloads,
-    analysisData?.assembly?.accession,
-    analysisData?.accession,
-    isAssembly,
     pipelineVersion,
   ]);
 };


### PR DESCRIPTION
This PR simplifies the legacy analysis known files hook to use files from the API Analysis.downloads field, which now contains the legacy files provided they really exist. This brings the V4.1 and V5 analysis pages more in line with the V6 analysis pages, i.e. they render files with paths available from the API only.

This should also fix the broken URLs of legacy, private analyses where e.g. no pre-signed URL can be constructed by the front-end for a private V5 qc file.