### PR TITLE
Genome Browser uses Jbrowse and IndexedDB contig search

### DIFF
--- a/cypress/e2e/compressed_tsv_table.js
+++ b/cypress/e2e/compressed_tsv_table.js
@@ -1,0 +1,51 @@
+import config from 'utils/config';
+import { openPage, waitForPageLoad } from '../util/util.js';
+
+describe('TSV table loaders', () => {
+  it('renders an ordinary TSV without requesting a BGZF index', () => {
+    const accession = 'MGYG000000001';
+    const tsvUrl = `${Cypress.env('FIXTURE_BASE')}/plain-tsv-table.tsv`;
+
+    cy.fixture('apiv2/genomes/genomeDetail_MGYG000000001.json').then(
+      (genome) => {
+        cy.intercept('GET', `${config.api_v2}genomes/${accession}`, {
+          ...genome,
+          downloads: [
+            ...genome.downloads,
+            {
+              alias: 'MGYG000000001_kegg_pathway_completeness.tsv',
+              download_group: 'pathways_and_systems.kegg_pathways',
+              download_type: 'Functional analysis',
+              file_type: 'tsv',
+              long_description: 'KEGG pathway completeness',
+              short_description: 'KEGG pathway completeness',
+              url: tsvUrl,
+            },
+          ],
+        });
+      }
+    );
+    cy.intercept(
+      'GET',
+      `${config.api_v2}genomes/${accession}/annotations`,
+      { fixture: 'apiv2/genomes/genomeAnnotations_MGYG000000001.json' }
+    );
+    cy.intercept('GET', tsvUrl).as('plainTsv');
+
+    openPage(`genomes/${accession}#kegg-pathway-analysis`);
+    waitForPageLoad(`Genome ${accession}`);
+
+    cy.get('.compressed-tsv-table').should('be.visible');
+    cy.get('.compressed-tsv-table thead').should(
+      'contain.text',
+      'Pathway Accession'
+    );
+    cy.get('.compressed-tsv-table tbody tr').should('have.length', 3);
+    cy.get('.compressed-tsv-table').should('contain.text', 'map00010');
+    cy.wait('@plainTsv');
+
+    cy.contains('button', 'Switch to chart view').click();
+    cy.get('.compressed-tsv-table .highcharts-container').should('be.visible');
+    cy.get('@plainTsv.all').should('have.length', 1);
+  });
+});

--- a/cypress/e2e/contig_viewer.js
+++ b/cypress/e2e/contig_viewer.js
@@ -21,7 +21,7 @@ describe('Contig viewer and indexer on bgzipped gffs', () => {
     cy.contains('Analysis MGYA00000002')
       .should('be.visible');
     cy.contains('File download required').should('be.visible');
-    cy.contains('button', 'Download & index GFF').click();
+    cy.contains('button', 'View & search contigs').click();
     cy.get('.Toastify__toast-body').should('contain', 'Downloading');
     cy.get('.Toastify__toast-body').should('contain', 'Indexed 6 assembly contigs');
     cy.contains('ERZ101_1')
@@ -34,11 +34,68 @@ describe('Contig viewer and indexer on bgzipped gffs', () => {
     cy.contains('ERZ857107_user_mobilome_full.gff.gz').should('be.visible');
     cy.contains('ERZ101_1|inverted_repeat_element').should('be.visible');
 
+    cy.get('#contig-search-all').should('have.attr', 'placeholder', 'Search GFF');
+    cy.contains('button', 'IPR000771').click();
+    cy.get('#contig-search-all').should('have.value', 'IPR000771').clear();
+
+    cy.get('#contig-search-all').type('IPR003593');
+    cy.location('search').should(
+      'contain',
+      'allAnnotationsSearch=IPR003593'
+    );
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 3);
+    cy.get('.vf-table__body code').should(
+      'contain.text',
+      'interpro=IPR003593;'
+    );
+    cy.get('.vf-table__body mark').should('have.text', 'IPR003593');
+    cy.contains('Browsing 6 annotated contigs').should('be.visible');
+    cy.get('#contig-search-all').clear();
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 6);
+
+    cy.get('#contig-search-all').type('erz101_4');
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 3);
+    cy.get('.vf-table__body code').should('contain.text', 'Contig ID=ERZ101_4;');
+    cy.get('.vf-table__body mark').should('have.text', 'ERZ101_4');
+    cy.get('#contig-search-all').clear();
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 6);
+
+    cy.get('#searchitem-interpro_').focus();
+    cy.get('.mg-typeahead-suggestion').should('have.length.greaterThan', 0);
+
+    cy.contains('summary', 'Gene Ontology term').click();
+    cy.get('#contig_required_switch_gos').click();
+    cy.location('search').should(
+      'contain',
+      'geneOntologyTermSearch=ANY'
+    );
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 0);
+    cy.get('#contig_required_switch_gos').click();
+    cy.get('.vf-table__body > .vf-table__row').should('have.length', 6);
+
     cy.get('#searchitem-interpro_').type('IPR003593');
     cy.get('.vf-table__body > .vf-table__row').should('have.length', 1);
     cy.get('#searchitem-interpro_').type('1');
     cy.get('.vf-table__body > .vf-table__row').should('have.length', 0);
     cy.contains('button', 'Remove contig index').click();
     cy.get('.Toastify__toast-body').should('contain', 'Contig index removed');
+  });
+
+  it('Should load the bgzipped GFF preview only once', () => {
+    openPage('analyses/MGYA00000002/contigs-viewer/gff-preview');
+    waitForPageLoad('Analysis MGYA00000002');
+    cy.get('[data-cy="assembly-tsv-table"], .compressed-tsv-table')
+      .should('be.visible');
+    cy.window().then((win) => {
+      const countGffRequests = () =>
+        win.performance
+          .getEntriesByType('resource')
+          .filter(({ name }) => name.includes('ERZ857107_annotation_summary.gff'))
+          .length;
+      const settledRequestCount = countGffRequests();
+      cy.wait(500).then(() => {
+        expect(countGffRequests()).to.equal(settledRequestCount);
+      });
+    });
   });
 });

--- a/cypress/fixtures/plain-tsv-table.tsv
+++ b/cypress/fixtures/plain-tsv-table.tsv
@@ -1,0 +1,4 @@
+pathway_accession	completeness
+map00010	90
+map00020	75
+map00030	50

--- a/src/components/Analysis/BgZipService.ts
+++ b/src/components/Analysis/BgZipService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 
 import * as pako from 'pako';
-import { Download } from 'interfaces/index';
+import { Download } from '@/interfaces';
 import { find } from 'lodash-es';
 import { fetchWithCheck } from 'utils/fetch';
 
@@ -16,6 +16,8 @@ export class BGZipService {
   private gziIndex: GziBlock[] = [];
 
   public isInitialized = false;
+
+  private initializePromise?: Promise<boolean>;
 
   private readonly dataFileUrl: string;
 
@@ -34,9 +36,16 @@ export class BGZipService {
       (index) => index.index_type === index_type
     );
 
-    if (!indexFile) return undefined;
+    if (indexFile) return indexFile.url;
 
-    return indexFile.url;
+    if (download.index_file?.index_type !== index_type) return undefined;
+    if (download.index_file.url) return download.index_file.url;
+    if (!download.index_file.path) return undefined;
+
+    const indexFilename = download.index_file.path.split('/').pop();
+    if (!indexFilename) return undefined;
+
+    return download.url.replace(/[^/]+$/, indexFilename);
   }
 
   constructor(
@@ -57,9 +66,15 @@ export class BGZipService {
     }
   }
 
-  public async initialize(): Promise<boolean> {
-    if (this.isInitialized) return true;
+  public initialize(): Promise<boolean> {
+    if (this.isInitialized) return Promise.resolve(true);
+    if (this.initializePromise) return this.initializePromise;
 
+    this.initializePromise = this.loadIndex();
+    return this.initializePromise;
+  }
+
+  private async loadIndex(): Promise<boolean> {
     if (!this.indexFileUrl) {
       console.warn(
         'No index file found for BGZip download; random-access BGZF methods will not be available.'
@@ -91,6 +106,7 @@ export class BGZipService {
       console.error('Error fetching GZI index:', errorMessage);
       return false;
     } finally {
+      this.initializePromise = undefined;
       console.groupEnd();
     }
   }

--- a/src/components/Analysis/ContigViewer/ContigSearch/index.tsx
+++ b/src/components/Analysis/ContigViewer/ContigSearch/index.tsx
@@ -1,74 +1,214 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Download, PaginatedList } from '@/interfaces';
 import {
   Contig,
   db,
+  GffAttributeIndexSpec,
+  getGffIndexSpec,
   importGffToIndexedDB,
+  PRESENCE_FIELD_BY_ATTRIBUTE,
   resetDb,
+  TypeAheadAttributes,
 } from 'utils/locallyIndexedGff';
-import { useEffectOnce } from 'react-use';
+import { useDebounce, useEffectOnce } from 'react-use';
 import { toast } from 'react-toastify';
 import { BGZipService } from 'components/Analysis/BgZipService';
 import Loading from 'components/UI/Loading';
 import EMGTable from 'components/UI/EMGTable';
-import { createSharedQueryParamContextForTable } from 'hooks/queryParamState/useQueryParamState';
-import { SharedTextQueryParam } from 'hooks/queryParamState/QueryParamStore/QueryParamContext';
+import useQueryParamState from 'hooks/queryParamState/useQueryParamState';
+import SharedQueryParamsProvider, {
+  SharedNumberQueryParam,
+  SharedQueryParamContext,
+  SharedTextQueryParam,
+} from 'hooks/queryParamState/QueryParamStore/QueryParamContext';
 import { ContigFeatureFlag } from 'components/Analysis/ContigViewer/Table';
 import { useLGV } from 'components/Analysis/ContigViewer/V2ContigViewContext';
 import ContigTypeaheadFilter from 'components/Analysis/ContigViewer/Filter/ContigFilterTypeahead';
 import { Collection } from 'dexie';
 import { KEYWORD_ANY } from 'components/UI/TextInputTypeahead';
 import { filesize } from 'filesize';
-import InfoBanner from 'components/UI/InfoBanner';
+import { camelCase } from 'lodash-es';
+import 'components/Analysis/ContigViewer/style.css';
 
-const {
-  usePage,
-  useInterproSearch,
-  usePfamSearch,
-  useCogCategorySearch,
-  useKeggOrthlogSearch,
-  useGeneOntologySearch,
-  withQueryParamProvider,
-} = createSharedQueryParamContextForTable('', {
-  interproSearch: SharedTextQueryParam(''),
-  pfamSearch: SharedTextQueryParam(''),
-  cogCategorySearch: SharedTextQueryParam(''),
-  keggOrthlogSearch: SharedTextQueryParam(''),
-  geneOntologySearch: SharedTextQueryParam(''),
-});
+const ALL_ANNOTATIONS_SEARCH_PARAM = 'allAnnotationsSearch';
+const SEARCH_ALL_EXAMPLES = ['IPR000771', 'PF00115'];
+const SEARCH_GENOMES_EXAMPLES = ['AMR', 'Glutaminase', 'BETA-LACTAM'];
+
+type SearchableContig = Contig & {
+  globalSearchMatch?: string;
+};
+
+export const findFirstMatchingAnnotationBlock = (
+  annotationText: string,
+  rawTerm: string
+): string | undefined => {
+  const term = rawTerm.trim().toLowerCase();
+  if (!term) return undefined;
+
+  const matchIndex = (annotationText || '').toLowerCase().indexOf(term);
+  if (matchIndex < 0) return undefined;
+
+  const blockStart = annotationText.lastIndexOf(';', matchIndex - 1) + 1;
+  const separatorIndex = annotationText.indexOf(';', matchIndex);
+  const blockEnd =
+    separatorIndex < 0 ? annotationText.length : separatorIndex + 1;
+  return annotationText.slice(blockStart, blockEnd).trim();
+};
+
+export const findGlobalSearchMatch = (
+  contig: Contig,
+  rawTerm: string
+): string | undefined => {
+  const term = rawTerm.trim().toLowerCase();
+  if (!term) return undefined;
+  if (contig.contigName.toLowerCase().includes(term)) {
+    return `Contig ID=${contig.contigName};`;
+  }
+  return findFirstMatchingAnnotationBlock(contig.annotationText, term);
+};
+
+const HighlightedAnnotationMatch: React.FC<{
+  text: string;
+  searchTerm: string;
+}> = ({ text, searchTerm }) => {
+  const matchIndex = text
+    .toLowerCase()
+    .indexOf(searchTerm.trim().toLowerCase());
+  if (matchIndex < 0) return <>{text}</>;
+
+  const matchEnd = matchIndex + searchTerm.trim().length;
+  return (
+    <code>
+      {text.slice(0, matchIndex)}
+      <mark>{text.slice(matchIndex, matchEnd)}</mark>
+      {text.slice(matchEnd)}
+    </code>
+  );
+};
+
+const SearchAllFilter: React.FC<{
+  accession: string;
+  includeGenomeExamples: boolean;
+}> = ({ accession, includeGenomeExamples }) => {
+  const [searchTerm, setSearchTerm] = useQueryParamState<string>(
+    ALL_ANNOTATIONS_SEARCH_PARAM
+  );
+  const [value, setValue] = useState(searchTerm || '');
+  const examples = includeGenomeExamples
+    ? [...SEARCH_ALL_EXAMPLES, ...SEARCH_GENOMES_EXAMPLES, `${accession}_00001`]
+    : SEARCH_ALL_EXAMPLES;
+
+  useEffect(() => {
+    setValue(searchTerm || '');
+  }, [searchTerm]);
+
+  useDebounce(
+    () => {
+      setSearchTerm(value);
+    },
+    300,
+    [value]
+  );
+
+  return (
+    <div className="vf-form__item mg-textsearch">
+      <label className="vf-form__label" htmlFor="contig-search-all">
+        Search all
+      </label>
+      <input
+        id="contig-search-all"
+        type="search"
+        className="vf-form__input"
+        placeholder="Search GFF"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <small className="vf-form__helper mg-contig-search-examples">
+        <span>Examples:</span>
+        <span className="mg-contig-search-example-links">
+          {examples.map((example, index) => (
+            <button
+              key={example}
+              type="button"
+              className="vf-button vf-button--link vf-button--sm mg-contig-search-example"
+              onClick={() => setValue(example)}
+            >
+              {example}
+              {index < examples.length - 1 ? ',' : ''}
+            </button>
+          ))}
+        </span>
+      </small>
+    </div>
+  );
+};
 
 const getFileSize = async (dataFileUrl: string): Promise<number> => {
-  const headResponse = await fetch(dataFileUrl, { method: 'HEAD' });
+  let response = await fetch(dataFileUrl, { method: 'HEAD' });
+  if (!response.ok || !response.headers.get('content-length')) {
+    const controller = new AbortController();
+    response = await fetch(dataFileUrl, {
+      headers: { Range: 'bytes=0-0' },
+      signal: controller.signal,
+    });
+    if (response.status !== 206) controller.abort();
+  }
+  const contentRange = response.headers.get('content-range');
   const contentLength = Number(
-    headResponse.headers.get('content-length') || '0'
+    contentRange?.split('/')[1] || response.headers.get('content-length') || '0'
   );
   console.debug(`Compressed file size: ${contentLength}`);
   return contentLength;
 };
 
-const annotationTypesForExistenceDisplay: {
-  annotKeyInIndex: string;
-  annotDisplay: string;
-}[] = [
+export type ContigSearchFilterConfig = {
+  title: string;
+  attribute: TypeAheadAttributes;
+  placeholder: string;
+  gffKey?: string | string[];
+  featureDisplay?: string;
+  searchParamName?: string;
+};
+
+export const getFilterSearchParamName = (
+  filter: ContigSearchFilterConfig
+): string => filter.searchParamName ?? camelCase(`${filter.title} search`);
+
+const assemblyFilterConfig: ContigSearchFilterConfig[] = [
   {
-    annotKeyInIndex: 'hasInterpros',
-    annotDisplay: 'interpro',
+    title: 'InterPro',
+    attribute: 'interpros',
+    placeholder: 'IPR015200',
+    gffKey: 'interpro',
+    featureDisplay: 'interpro',
   },
   {
-    annotKeyInIndex: 'hasPfams',
-    annotDisplay: 'pfam',
+    title: 'Pfam',
+    attribute: 'pfams',
+    placeholder: 'PF12574',
+    gffKey: 'pfam',
+    featureDisplay: 'pfam',
   },
   {
-    annotKeyInIndex: 'hasCogs',
-    annotDisplay: 'cog',
+    title: 'COG Category',
+    attribute: 'cogs',
+    placeholder: 'S',
+    gffKey: 'cog',
+    featureDisplay: 'cog',
   },
   {
-    annotKeyInIndex: 'hasKeggs',
-    annotDisplay: 'kegg',
+    title: 'KEGG Ortholog',
+    attribute: 'keggs',
+    placeholder: 'ko:K03325',
+    gffKey: 'kegg',
+    featureDisplay: 'kegg',
   },
   {
-    annotKeyInIndex: 'hasGos',
-    annotDisplay: 'go',
+    title: 'Gene Ontology term',
+    attribute: 'gos',
+    placeholder: 'GO:0044281',
+    gffKey: 'Ontology_term',
+    featureDisplay: 'go',
   },
 ];
 
@@ -76,20 +216,81 @@ const ContigSearch: React.FC<{
   gffDownload: Download;
   fastaDownload: Download;
   assemblyAccession: string;
-}> = ({ gffDownload, fastaDownload, assemblyAccession }) => {
+  entityLabel?: string;
+  filterConfig?: ContigSearchFilterConfig[];
+  hideUnavailableFilters?: boolean;
+}> = ({
+  gffDownload,
+  fastaDownload,
+  assemblyAccession,
+  entityLabel = 'assembly',
+  filterConfig = assemblyFilterConfig,
+  hideUnavailableFilters = false,
+}) => {
   const [gffSize, setGffSize] = useState<number>();
   const [existingIndexChecked, setExistingIndexChecked] =
     useState<boolean>(false);
   const [isIndexing, setIsIndexing] = useState<boolean>(false);
   const [isIndexed, setIsIndexed] = useState<boolean>(false);
   const [isStale, setIsStale] = useState<boolean>(false);
-  const [interproSearch] = useInterproSearch<string>();
-  const [pfamSearch] = usePfamSearch<string>();
-  const [cogSearch] = useCogCategorySearch<string>();
-  const [keggSearch] = useKeggOrthlogSearch<string>();
-  const [goSearch] = useGeneOntologySearch<string>();
+  const [totalContigsCount, setTotalContigsCount] = useState<number>(0);
+  const [availableAttributes, setAvailableAttributes] = useState<
+    Set<TypeAheadAttributes> | undefined
+  >();
+  const { queryParams } = useContext(SharedQueryParamContext);
+  const [allAnnotationsSearch] = useQueryParamState<string>(
+    ALL_ANNOTATIONS_SEARCH_PARAM
+  );
+  const searchTermsByAttribute = useMemo<
+    Partial<Record<TypeAheadAttributes, string>>
+  >(
+    () =>
+      Object.fromEntries(
+        filterConfig.map((filter) => {
+          const param = queryParams[getFilterSearchParamName(filter)];
+          return [
+            filter.attribute,
+            (param?.value as string | undefined) ?? param?.defaultValue ?? '',
+          ];
+        })
+      ),
+    [filterConfig, queryParams]
+  );
+
+  const attrsToIndex = useMemo(
+    () =>
+      filterConfig.map(
+        ({ gffKey, attribute }) =>
+          ({
+            gffKey: gffKey ?? attribute,
+            field: attribute,
+          } as GffAttributeIndexSpec)
+      ),
+    [filterConfig]
+  );
+
+  const indexSpec = useMemo(
+    () => getGffIndexSpec(attrsToIndex),
+    [attrsToIndex]
+  );
 
   const { navTo: navToContig, ready: isViewerReady } = useLGV();
+
+  const visibleFilterConfig = useMemo(() => {
+    if (!hideUnavailableFilters || !availableAttributes) return filterConfig;
+    return filterConfig.filter(({ attribute }) =>
+      availableAttributes.has(attribute)
+    );
+  }, [availableAttributes, filterConfig, hideUnavailableFilters]);
+
+  const visibleSearchTermsDependency = useMemo(
+    () =>
+      visibleFilterConfig
+        .map(({ attribute }) => searchTermsByAttribute[attribute] ?? '')
+        .concat(allAnnotationsSearch || '')
+        .join('\u0001'),
+    [allAnnotationsSearch, visibleFilterConfig, searchTermsByAttribute]
+  );
 
   useEffect(() => {
     getFileSize(gffDownload.url).then(setGffSize);
@@ -101,8 +302,8 @@ const ContigSearch: React.FC<{
     count: 0,
     items: [],
   } as PaginatedList<Contig>);
-  const [pageNum, setPageNum] = usePage<number>();
-  const PAGESIZE = 10;
+  const [pageNum, setPageNum] = useQueryParamState<number>('page');
+  const PAGESIZE = 25;
 
   async function searchContigs(): Promise<PaginatedList<Contig>> {
     setIsStale(true);
@@ -113,64 +314,68 @@ const ContigSearch: React.FC<{
     const contigsTable = db.contigs;
     let contigsColl: Collection<Contig> | null = null;
 
-    const presenceIndexFor: Record<
-      'interpros' | 'pfams' | 'cogs' | 'keggs' | 'gos',
-      string
-    > = {
-      interpros: 'annotationsPresence.hasInterpros',
-      pfams: 'annotationsPresence.hasPfams',
-      cogs: 'annotationsPresence.hasCogs',
-      keggs: 'annotationsPresence.hasKeggs',
-      gos: 'annotationsPresence.hasGos',
-    };
-
     const applyAttrFilter = (
       coll: Collection<Contig> | null,
-      idxPath: 'interpros' | 'pfams' | 'cogs' | 'keggs' | 'gos',
+      idxPath: TypeAheadAttributes,
       rawTerm?: string
     ): Collection<Contig> | null => {
-      const term = (rawTerm || '').trim().toUpperCase();
+      const term = (rawTerm || '').trim();
       if (!term) return coll;
 
       if (term === KEYWORD_ANY) {
-        // Presence-only: use the indexed boolean flag on the contig
-        const base = contigsTable.where(presenceIndexFor[idxPath]).equals(1);
+        const presenceField = PRESENCE_FIELD_BY_ATTRIBUTE[idxPath];
+        const base = contigsTable
+          .where(`annotationsPresence.${presenceField}`)
+          .equals(1);
         return coll
           ? coll.and(
-              (c) =>
-                (c as any).annotationsPresence?.[
-                  `has${idxPath.charAt(0).toUpperCase()}${idxPath.slice(1)}`
-                ] === 1
+              (c) => (c as any).annotationsPresence?.[presenceField] === 1
             )
           : base;
       }
 
-      // Exact match via multiEntry index on annotations.*
       const indexName = `annotations.${idxPath}`;
-      const base = contigsTable.where(indexName).equals(term);
-      return coll
-        ? coll.and(
-            (c) =>
-              (
-                (c.annotations as any)?.[idxPath] as string[] | undefined
-              )?.includes(term) as boolean
-          )
-        : base;
+      const termUpper = term.toUpperCase();
+      const hasExactMatch = (c: Contig) =>
+        ((c.annotations as any)?.[idxPath] as string[] | undefined)?.some(
+          (value) => value.toUpperCase() === termUpper
+        ) ?? false;
+      const base = (contigsTable.where(indexName) as any)
+        .startsWithIgnoreCase(term)
+        .and(hasExactMatch);
+      return coll ? coll.and(hasExactMatch) : base;
     };
 
-    // Apply all filters
-    contigsColl = applyAttrFilter(contigsColl, 'interpros', interproSearch);
-    contigsColl = applyAttrFilter(contigsColl, 'pfams', pfamSearch);
-    contigsColl = applyAttrFilter(contigsColl, 'cogs', cogSearch);
-    contigsColl = applyAttrFilter(contigsColl, 'keggs', keggSearch);
-    contigsColl = applyAttrFilter(contigsColl, 'gos', goSearch);
+    for (const { attribute } of visibleFilterConfig) {
+      contigsColl = applyAttrFilter(
+        contigsColl,
+        attribute,
+        searchTermsByAttribute[attribute]
+      );
+    }
+
+    const globalSearchTerm = (allAnnotationsSearch || '').trim();
+    if (globalSearchTerm) {
+      const hasGlobalMatch = (contig: Contig) =>
+        !!findGlobalSearchMatch(contig, globalSearchTerm);
+      contigsColl = contigsColl
+        ? contigsColl.and(hasGlobalMatch)
+        : contigsTable.filter(hasGlobalMatch);
+    }
 
     contigsColl = contigsColl || contigsTable.toCollection();
 
     const totalContigs = await contigsColl.count();
     const items = await contigsColl.offset(offset).limit(PAGESIZE).toArray();
 
-    return { count: totalContigs, items };
+    const itemsWithMatches: SearchableContig[] = globalSearchTerm
+      ? items.map((contig) => ({
+          ...contig,
+          globalSearchMatch: findGlobalSearchMatch(contig, globalSearchTerm),
+        }))
+      : items;
+
+    return { count: totalContigs, items: itemsWithMatches };
   }
 
   useEffect(() => {
@@ -179,27 +384,67 @@ const ContigSearch: React.FC<{
       .then(setContigsTableData)
       .finally(() => setIsStale(false));
     //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isIndexed, pageNum, interproSearch, pfamSearch]);
+  }, [isIndexed, pageNum, visibleSearchTermsDependency]);
 
   useEffect(() => {
     if (!isIndexed) return;
     setPageNum(1);
     //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [interproSearch, pfamSearch]);
+  }, [visibleSearchTermsDependency]);
+
+  useEffect(() => {
+    setAvailableAttributes(undefined);
+  }, [gffDownload.url, indexSpec]);
+
+  useEffect(() => {
+    if (!isIndexed || !hideUnavailableFilters) return;
+    let cancelled = false;
+
+    Promise.all(
+      filterConfig.map(async ({ attribute }) => {
+        const presenceField = PRESENCE_FIELD_BY_ATTRIBUTE[attribute];
+        const count = await db.contigs
+          .where(`annotationsPresence.${presenceField}`)
+          .equals(1)
+          .limit(1)
+          .count();
+        return [attribute, count > 0] as const;
+      })
+    ).then((availability) => {
+      if (cancelled) return;
+      setAvailableAttributes(
+        new Set(
+          availability
+            .filter(([, isAvailable]) => isAvailable)
+            .map(([attribute]) => attribute)
+        )
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filterConfig, hideUnavailableFilters, isIndexed]);
 
   useEffectOnce(() => {
     if (!isIndexed && !existingIndexChecked) {
-      db.meta
-        .get('sourceUrl')
-        .then((row) => {
-          if (row?.value && row.value === gffDownload.url) {
-            console.debug(`File already indexed in local db: ${row.value}`);
+      Promise.all([db.meta.get('sourceUrl'), db.meta.get('indexSpec')])
+        .then(async ([sourceUrlRow, indexSpecRow]) => {
+          if (
+            sourceUrlRow?.value &&
+            sourceUrlRow.value === gffDownload.url &&
+            indexSpecRow?.value === indexSpec
+          ) {
+            console.debug(
+              `File already indexed in local db: ${sourceUrlRow.value}`
+            );
+            setTotalContigsCount(await db.contigs.count());
             setIsIndexed(true);
             toast.success(`Contigs have been loaded from an earlier visit.`, {
               autoClose: 5000,
             });
           } else {
-            resetDb();
+            await resetDb();
           }
           setExistingIndexChecked(true);
         })
@@ -233,26 +478,43 @@ const ContigSearch: React.FC<{
         accessor: (row) => row.annotationsPresence,
         id: 'features',
         Cell: ({ cell }) => {
-          const flags = annotationTypesForExistenceDisplay.map(
-            ({ annotKeyInIndex, annotDisplay }) => {
+          const flags = visibleFilterConfig
+            .filter(({ featureDisplay }) => featureDisplay)
+            .map(({ attribute, featureDisplay }) => {
+              const annotKeyInIndex = PRESENCE_FIELD_BY_ATTRIBUTE[attribute];
               return (
                 <ContigFeatureFlag
                   key={annotKeyInIndex}
-                  annotationType={annotDisplay}
+                  annotationType={featureDisplay as string}
                   present={cell.value?.[annotKeyInIndex] > 0}
                 />
               );
-            }
-          );
+            });
           return <div className="emg-contig-feature-flags">{flags}</div>;
         },
       },
+      ...((allAnnotationsSearch || '').trim()
+        ? [
+            {
+              Header: 'Search match',
+              accessor: (row: SearchableContig) => row.globalSearchMatch,
+              id: 'global-search-match',
+              isFullWidth: true,
+              className: 'break-anywhere',
+              Cell: ({ cell }) => (
+                <HighlightedAnnotationMatch
+                  text={cell.value || ''}
+                  searchTerm={allAnnotationsSearch}
+                />
+              ),
+            },
+          ]
+        : []),
     ],
-    [navToContig]
+    [allAnnotationsSearch, visibleFilterConfig, navToContig]
   );
 
   const gffIndex = BGZipService.getIndexFileUrl(gffDownload);
-  if (!gffIndex) return <InfoBanner type="error" title="GFF index not found" />;
 
   const { start: fetchAndIndex, cancel: cancelFetchAndIndex } =
     importGffToIndexedDB({
@@ -262,7 +524,7 @@ const ContigSearch: React.FC<{
       fastaUrl: fastaDownload.url,
       fastaFaiUrl: BGZipService.getIndexFileUrl(fastaDownload, 'fai'),
       fastaGziUrl: BGZipService.getIndexFileUrl(fastaDownload, 'gzi'),
-      attrsToIndex: ['interpro', 'pfam', 'cog', 'kegg', 'go'],
+      attrsToIndex,
       batchSize: 200,
       onProgress: ({ percent }) => {
         toast.update(`${gffDownload.alias}-index-progress`, {
@@ -280,8 +542,9 @@ const ContigSearch: React.FC<{
       },
       onEnd: ({ contigsCount }) => {
         setIsIndexing(false);
+        setTotalContigsCount(contigsCount);
         toast.dismiss(`${gffDownload.alias}-index-progress`);
-        toast.success(`Indexed ${contigsCount} assembly contigs`, {
+        toast.success(`Indexed ${contigsCount} ${entityLabel} contigs`, {
           autoClose: 5000,
         });
         setIsIndexed(true);
@@ -294,7 +557,12 @@ const ContigSearch: React.FC<{
       },
     });
 
-  if (gffSize === undefined || !existingIndexChecked || !isViewerReady)
+  if (
+    gffSize === undefined ||
+    !existingIndexChecked ||
+    !isViewerReady ||
+    (isIndexed && hideUnavailableFilters && !availableAttributes)
+  )
     return <Loading size="small" />;
 
   if (!isIndexed) {
@@ -321,7 +589,7 @@ const ContigSearch: React.FC<{
                 fetchAndIndex();
               }}
             >
-              Download & index GFF
+              View & search contigs
             </button>
           )}
           {isIndexing && (
@@ -341,45 +609,45 @@ const ContigSearch: React.FC<{
 
   return (
     <>
-      <div className="vf-grid vf-grid__col-6">
-        <div className="vf-stack vf-stack--400">
+      <section className="vf-grid mg-contigs-list">
+        <div className="vf-stack vf-stack--800">
           <h4 className="text-heading--4">Search by contained annotations</h4>
-          <ContigTypeaheadFilter
-            title="InterPro"
-            attribute="interpros"
-            placeholder="IPR015200"
+          <SearchAllFilter
+            accession={assemblyAccession}
+            includeGenomeExamples={entityLabel === 'genome'}
           />
-          <ContigTypeaheadFilter
-            title="Pfam"
-            attribute="pfams"
-            placeholder="PF12574"
-          />
-          <ContigTypeaheadFilter
-            title="COG Category"
-            attribute="cogs"
-            placeholder="S"
-          />
-          <ContigTypeaheadFilter
-            title="KEGG Ortholog"
-            attribute="keggs"
-            placeholder="ko:K03325"
-          />
-          <ContigTypeaheadFilter
-            title="Gene Ontology term"
-            attribute="gos"
-            placeholder="GO:0044281"
-          />
+          {visibleFilterConfig.length ? (
+            visibleFilterConfig.map((filter, index) => (
+              <ContigTypeaheadFilter
+                key={filter.attribute}
+                title={filter.title}
+                attribute={filter.attribute}
+                placeholder={filter.placeholder}
+                searchParamName={getFilterSearchParamName(filter)}
+                defaultOpen={index === 0}
+              />
+            ))
+          ) : (
+            <p className="vf-text-body vf-text-body--3">
+              No searchable annotations were found in this GFF.
+            </p>
+          )}
         </div>
-        <div className="vf-grid__col--span-5">
-          <EMGTable
-            cols={contigsColumns}
-            data={contigsTableData as PaginatedList<Contig>}
-            expectedPageSize={PAGESIZE}
-            isStale={isStale}
-            loading={isStale || !isIndexed}
-          />
-        </div>
-      </div>
+        <EMGTable
+          cols={contigsColumns}
+          data={contigsTableData as PaginatedList<Contig>}
+          expectedPageSize={PAGESIZE}
+          Title={
+            <>
+              {entityLabel === 'genome' ? 'Genome' : 'Assembly'} Contigs (
+              {contigsTableData.count})
+            </>
+          }
+          className="mg-contigs-table"
+          isStale={isStale}
+          loading={isStale || !isIndexed}
+        />
+      </section>
       <div
         className="vf-box vf-box-theme--primary vf-box--easy"
         style={{
@@ -389,7 +657,7 @@ const ContigSearch: React.FC<{
         <div className="vf-flag vf-flag--top vf-flag--reversed vf-flag--800">
           <div className="vf-flag__body">
             <p className="vf-text-body vf-text-body--3">
-              Browsing {contigsTableData.count} annotated contigs from{' '}
+              Browsing {totalContigsCount} annotated contigs from{' '}
               {gffDownload.alias}
             </p>
           </div>
@@ -399,6 +667,7 @@ const ContigSearch: React.FC<{
               onClick={() =>
                 resetDb().then(() => {
                   setIsIndexed(false);
+                  setTotalContigsCount(0);
                   setContigsTableData({
                     count: 0,
                     items: [],
@@ -418,4 +687,32 @@ const ContigSearch: React.FC<{
   );
 };
 
-export default React.memo(withQueryParamProvider(ContigSearch));
+const ContigSearchWithQueryParams: React.FC<
+  React.ComponentProps<typeof ContigSearch>
+> = (props) => {
+  const filterConfig = props.filterConfig ?? assemblyFilterConfig;
+  const queryParamDefinitions = useMemo(
+    () => ({
+      page: SharedNumberQueryParam(1),
+      pageSize: SharedNumberQueryParam(10),
+      order: SharedTextQueryParam(''),
+      search: SharedTextQueryParam(''),
+      [ALL_ANNOTATIONS_SEARCH_PARAM]: SharedTextQueryParam(''),
+      ...Object.fromEntries(
+        filterConfig.map((filter) => [
+          getFilterSearchParamName(filter),
+          SharedTextQueryParam(''),
+        ])
+      ),
+    }),
+    [filterConfig]
+  );
+
+  return (
+    <SharedQueryParamsProvider params={queryParamDefinitions}>
+      <ContigSearch {...props} filterConfig={filterConfig} />
+    </SharedQueryParamsProvider>
+  );
+};
+
+export default React.memo(ContigSearchWithQueryParams);

--- a/src/components/Analysis/ContigViewer/Filter/ContigFilterTypeahead/index.tsx
+++ b/src/components/Analysis/ContigViewer/Filter/ContigFilterTypeahead/index.tsx
@@ -8,53 +8,59 @@ import {
 } from 'utils/locallyIndexedGff';
 import Switch from 'components/UI/Switch';
 import useQueryParamState from 'hooks/queryParamState/useQueryParamState';
-import { camelCase } from 'lodash-es';
 import 'styles/filters.css';
 
 type ContigTypeaheadFilterProps = {
   title: string;
   attribute: TypeAheadAttributes;
   placeholder: string;
+  searchParamName: string;
+  defaultOpen?: boolean;
 };
 
 const ContigTypeaheadFilter: React.FC<ContigTypeaheadFilterProps> = ({
   title,
   attribute,
   placeholder,
+  searchParamName,
+  defaultOpen = false,
 }) => {
-  const namespace = `${title.replaceAll(' ', '_').toLowerCase()}_`;
+  const namespace = `${title.replace(/ /g, '_').toLowerCase()}_`;
   const getSuggestions = useCallback(
     async (query: string): Promise<string[]> => {
       return await getTypeaheadSuggestions(query, attribute, 10);
     },
     [attribute]
   );
-  const [searchParam, setSearchParam] = useQueryParamState<string>(
-    camelCase(`${namespace} search`)
-  );
+  const [searchParam, setSearchParam] =
+    useQueryParamState<string>(searchParamName);
 
   const handleSwitch = () => {
     setSearchParam(searchParam === KEYWORD_ANY ? '' : KEYWORD_ANY);
   };
 
   return (
-    <fieldset className="vf-form__fieldset vf-stack vf-stack--200 mg-contig-text-filter">
-      <TextInputTypeahead
-        namespace={namespace}
-        placeholder={placeholder}
-        getSuggestions={getSuggestions}
-        title={title}
-      />
-      <div className="mg-switch-and-slider">
-        <Switch
-          id={`contig_required_switch_${attribute}`}
-          onChange={handleSwitch}
-          isOn={searchParam === KEYWORD_ANY}
-          controlled
+    <details className="mg-contig-filter-details" open={defaultOpen}>
+      <summary className="vf-form__legend mg-contig-filter">{title}</summary>
+      <fieldset className="vf-form__fieldset vf-stack vf-stack--200 mg-contig-text-filter">
+        <TextInputTypeahead
+          namespace={namespace}
+          searchParamName={searchParamName}
+          placeholder={placeholder}
+          getSuggestions={getSuggestions}
+          title={title}
         />
-        <p className="vf-form__helper">Filter by presence</p>
-      </div>
-    </fieldset>
+        <div className="mg-switch-and-slider">
+          <Switch
+            id={`contig_required_switch_${attribute}`}
+            onChange={handleSwitch}
+            isOn={searchParam === KEYWORD_ANY}
+            controlled
+          />
+          <p className="vf-form__helper">Filter by presence</p>
+        </div>
+      </fieldset>
+    </details>
   );
 };
 

--- a/src/components/Analysis/ContigViewer/Table/index.tsx
+++ b/src/components/Analysis/ContigViewer/Table/index.tsx
@@ -16,6 +16,7 @@ import {
   useCrates,
   useOfflineCrate,
 } from 'hooks/genomeViewer/CrateStore/useCrates';
+import { MGnifyDatum } from 'hooks/data/useData';
 
 type ContigFeatureProps = {
   annotationType: string;
@@ -27,7 +28,7 @@ export const ContigFeatureFlag: React.FC<ContigFeatureProps> = ({
   present,
 }) => {
   let color;
-  const letter = annotationType[0].toUpperCase();
+  let letter = annotationType[0].toUpperCase();
   switch (annotationType) {
     case 'cog':
       color = '#3b6fb6';
@@ -37,15 +38,101 @@ export const ContigFeatureFlag: React.FC<ContigFeatureProps> = ({
       break;
     case 'pfam':
       color = '#193f90';
+      letter = 'Pf';
       break;
     case 'interpro':
       color = '#734595';
+      letter = 'IP';
       break;
     case 'go':
       color = '#f49e17';
+      letter = 'GO';
+      break;
+    case 'gene':
+      color = '#707372';
+      letter = 'Gn';
       break;
     case 'antismash':
       color = '#b65417';
+      letter = 'AS';
+      break;
+    case 'antismash-function':
+      color = '#b65417';
+      letter = 'AF';
+      break;
+    case 'rfam':
+      color = '#501D0A';
+      letter = 'Rf';
+      break;
+    case 'mibig':
+      color = '#2D67AF';
+      letter = 'MB';
+      break;
+    case 'eggnog':
+      color = '#736EBD';
+      letter = 'Eg';
+      break;
+    case 'ec':
+      color = '#00876c';
+      letter = 'EC';
+      break;
+    case 'gecco':
+      color = '#587435';
+      letter = 'Ge';
+      break;
+    case 'dbcan':
+      color = '#9CB5EE';
+      letter = 'Cz';
+      break;
+    case 'dbcan-pul':
+      color = '#9CB5EE';
+      letter = 'CP';
+      break;
+    case 'dbcan-sub':
+      color = '#9CB5EE';
+      letter = 'CS';
+      break;
+    case 'amr':
+      color = '#d55e00';
+      letter = 'AM';
+      break;
+    case 'amr-drug':
+      color = '#d55e00';
+      letter = 'AD';
+      break;
+    case 'amr-subdrug':
+      color = '#d55e00';
+      letter = 'AS';
+      break;
+    case 'amr-element':
+      color = '#d55e00';
+      letter = 'AE';
+      break;
+    case 'amr-subelement':
+      color = '#d55e00';
+      letter = 'AT';
+      break;
+    case 'mobile':
+      color = '#cc79a7';
+      letter = 'Mo';
+      break;
+    case 'defense':
+      color = '#882255';
+      letter = 'Df';
+      break;
+    case 'virus':
+      color = '#44aa99';
+      letter = 'Vi';
+      break;
+    case 'viphog':
+      color = '#44aa99';
+      letter = 'Vg';
+      break;
+    case 'trna':
+      color = '#009e73';
+      break;
+    case 'ncrna':
+      color = '#3582B0';
       break;
     default:
       color = '#8d8f8e';
@@ -75,7 +162,8 @@ const ContigsTable: React.FC = () => {
   const [, setContigsPageCursor] = useQueryParamState('contigsPageCursor');
 
   const { overviewData: analysisOverviewData } = useContext(AnalysisContext);
-  const assemblyId = analysisOverviewData?.relationships?.assembly?.data?.id;
+  const assemblyId = (analysisOverviewData as MGnifyDatum | null)?.relationships
+    ?.assembly?.data?.id;
   const { crates, loading: loadingCrates } = useCrates(
     `assemblies/${assemblyId}/extra-annotations`
   );

--- a/src/components/Analysis/ContigViewer/Table/style.css
+++ b/src/components/Analysis/ContigViewer/Table/style.css
@@ -1,7 +1,8 @@
 div.emg-contig-feature-flag {
   border-radius: 0.4em;
   border: 2px solid;
-  width: 1.1em;
+  min-width: 1.1em;
+  max-width: 1.4em;
   height: 1.3em;
   display: flex;
   align-items: center;
@@ -11,7 +12,7 @@ div.emg-contig-feature-flag {
 
 div.emg-contig-feature-flags {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(18, 1fr);
   align-items: center;
   grid-column-gap: 4px;
 }

--- a/src/components/Analysis/ContigViewer/V2ContigViewContext.tsx
+++ b/src/components/Analysis/ContigViewer/V2ContigViewContext.tsx
@@ -13,6 +13,14 @@ type LGVContextValue = {
 
 const LGVContext = React.createContext<LGVContextValue | null>(null);
 
+const gffDisplayConfig = (alias: string, height?: number) => ({
+  type: 'LinearBasicDisplay',
+  displayId: `${alias}-LinearBasicDisplay`,
+  ...(height ? { height } : {}),
+});
+
+const ADDITIONAL_GFF_TRACK_HEIGHT = 60;
+
 export function useLGV() {
   const ctx = React.useContext(LGVContext);
   if (!ctx) throw new Error('useLGV must be used within <LGVProvider>');
@@ -43,6 +51,28 @@ export function LGVProvider({
     [fasta]
   );
 
+  const fastaAdapter = React.useMemo(() => {
+    if (fastaGziUrl) {
+      return {
+        type: 'BgzipFastaAdapter',
+        fastaLocation: { uri: fasta.url },
+        ...(fastaFaiUrl && { faiLocation: { uri: fastaFaiUrl } }),
+        gziLocation: { uri: fastaGziUrl },
+      };
+    }
+    if (fastaFaiUrl) {
+      return {
+        type: 'IndexedFastaAdapter',
+        fastaLocation: { uri: fasta.url },
+        faiLocation: { uri: fastaFaiUrl },
+      };
+    }
+    return {
+      type: 'UnindexedFastaAdapter',
+      fastaLocation: { uri: fasta.url },
+    };
+  }, [fasta.url, fastaFaiUrl, fastaGziUrl]);
+
   const viewState = React.useMemo(
     () =>
       createViewState({
@@ -51,18 +81,13 @@ export function LGVProvider({
           sequence: {
             type: 'ReferenceSequenceTrack',
             trackId: 'refseq',
-            adapter: {
-              type: 'BgzipFastaAdapter',
-              fastaLocation: { uri: fasta.url },
-              ...(fastaFaiUrl && { faiLocation: { uri: fastaFaiUrl } }),
-              ...(fastaGziUrl && { gziLocation: { uri: fastaGziUrl } }),
-            },
+            adapter: fastaAdapter,
           },
         },
         tracks: [],
         location: initialLoc,
       }),
-    [fasta.alias, fasta.url, fastaFaiUrl, fastaGziUrl, initialLoc]
+    [fasta.alias, fastaAdapter, initialLoc]
   );
 
   const view = (viewState as any)?.session?.view;
@@ -168,16 +193,20 @@ export function LGVProvider({
 
     const trackExists = !!session.getTrack?.(gff.alias);
 
-    const adapter: any = {
-      type: 'Gff3TabixAdapter',
-      gffGzLocation: { uri: gff.url },
-    };
-    if (csi || tbi) {
-      adapter.index = {
-        location: { uri: csi || tbi },
-        indexType: csi ? 'CSI' : 'TBI',
-      };
-    }
+    const adapter: any =
+      csi || tbi
+        ? {
+            type: 'Gff3TabixAdapter',
+            gffGzLocation: { uri: gff.url },
+            index: {
+              location: { uri: csi || tbi },
+              indexType: csi ? 'CSI' : 'TBI',
+            },
+          }
+        : {
+            type: 'Gff3Adapter',
+            gffLocation: { uri: gff.url },
+          };
 
     const conf = {
       type: 'FeatureTrack',
@@ -185,12 +214,7 @@ export function LGVProvider({
       name: gff.alias,
       assemblyNames: [fasta.alias],
       adapter,
-      displays: [
-        {
-          type: 'LinearBasicDisplay',
-          displayId: `${gff.alias}-LinearBasicDisplay`,
-        },
-      ],
+      displays: [gffDisplayConfig(gff.alias)],
     } as any;
 
     if (!trackExists) {
@@ -215,7 +239,7 @@ export function LGVProvider({
 
       let adapter: any = {
         type: 'Gff3Adapter',
-        uri: { uri: aGff.url },
+        gffLocation: { uri: aGff.url },
       };
       if (csi || tbi) {
         adapter = {
@@ -234,12 +258,7 @@ export function LGVProvider({
         name: aGff.alias,
         assemblyNames: [fasta.alias],
         adapter,
-        displays: [
-          {
-            type: 'LinearBasicDisplay',
-            displayId: `${aGff.alias}-LinearBasicDisplay`,
-          },
-        ],
+        displays: [gffDisplayConfig(aGff.alias, ADDITIONAL_GFF_TRACK_HEIGHT)],
       } as any;
 
       if (!trackExists) {

--- a/src/components/Analysis/ContigViewer/style.css
+++ b/src/components/Analysis/ContigViewer/style.css
@@ -1,42 +1,65 @@
 @media (min-width: 846px) {
-    .mg-contigs-list {
-        grid-template-columns: 25% 75%;
-    }
+  .mg-contigs-list {
+    grid-template-columns: 25% 75%;
+  }
 }
 
 .contig-igv-container {
-    min-height: 240px;
+  min-height: 240px;
 }
 
 .mg-contig-filter.vf-form__legend {
-    font-size: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.mg-contig-search-examples {
+  display: block;
+  width: 15rem;
+  max-width: 100%;
+  line-height: 1.2;
+}
+
+.mg-contig-search-example-links {
+  display: inline;
+}
+
+button.mg-contig-search-example {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: 1.2;
+  vertical-align: baseline;
 }
 
 details summary {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 details summary > * {
-    display: inline;
+  display: inline;
 }
 
 .gff-attribute {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.4rem 0.65rem;
-    font-family: monospace;
-    border: 1px solid rgba(100, 116, 139, 0.60);
-    border-radius: 6px;
-    color: #64748b;
-    font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.65rem;
+  font-family: monospace;
+  border: 1px solid rgba(100, 116, 139, 0.6);
+  border-radius: 6px;
+  color: #64748b;
+  font-size: 0.8rem;
 }
 
 .gff-attributes {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 /* fix scaling of labels in the JBrowse rubber band */
-[class*="-root-refLabel"],[class*="-majorTickLabel"],[class*="-minorTickLabel"] {
-    font-size: 12px !important;
+[class*='-root-refLabel'],
+[class*='-majorTickLabel'],
+[class*='-minorTickLabel'] {
+  font-size: 12px !important;
 }

--- a/src/components/Analysis/ContigViewer/v2index.tsx
+++ b/src/components/Analysis/ContigViewer/v2index.tsx
@@ -5,7 +5,6 @@ import './style.css';
 import useAnalysisDetail from 'hooks/data/useAnalysisDetail';
 import '@fontsource/roboto';
 
-import { JBrowseLinearGenomeView } from '@jbrowse/react-linear-genome-view2';
 import { find, includes } from 'lodash-es';
 import Loading from 'components/UI/Loading';
 import CompressedTSVTable from 'components/UI/CompressedTSVTable';
@@ -13,40 +12,33 @@ import DetailedVisualisationCard from '../VisualisationCards/DetailedVisualisati
 import { RouteTabs } from 'components/UI/Tabs';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import ContigSearch from 'components/Analysis/ContigViewer/ContigSearch';
-import {
-  LGVProvider,
-  useLGV,
-} from 'components/Analysis/ContigViewer/V2ContigViewContext';
-
-const ContigBrowser: React.FC = () => {
-  const { viewState } = useLGV();
-  if (!viewState) return <Loading size="small" />;
-  return (
-    <div className="vf-stack vf-stack--400">
-      <JBrowseLinearGenomeView viewState={viewState} />
-    </div>
-  );
-};
+import { LGVProvider } from 'components/Analysis/ContigViewer/V2ContigViewContext';
+import ContigBrowser from 'components/ContigViewer/ContigBrowser';
+import AdditionalGffNotice from 'components/ContigViewer/AdditionalGffNotice';
 
 const ContigsViewer: React.FC = () => {
   const accession = useURLAccession();
   const { data, loading, error } = useAnalysisDetail(accession);
+  const availableDownloads = useMemo(
+    () => data?.downloads ?? [],
+    [data?.downloads]
+  );
 
   const fasta = useMemo(() => {
-    if (!data) return null;
+    if (!availableDownloads.length) return null;
     return find(
-      data.downloads,
+      availableDownloads,
       (d) => d.file_type === 'fasta' && d.download_group === 'quality_control'
     );
-  }, [data]);
+  }, [availableDownloads]);
 
   const gff = useMemo(() => {
-    if (!data) return null;
+    if (!availableDownloads.length) return null;
     return find(
-      data.downloads,
+      availableDownloads,
       (d) => d.file_type === 'gff' && d.download_group === 'annotation_summary'
     );
-  }, [data]);
+  }, [availableDownloads]);
 
   const gffColumns = useMemo(
     () => [
@@ -112,13 +104,13 @@ const ContigsViewer: React.FC = () => {
   );
 
   const additionalGffs = useMemo(() => {
-    if (!data) return [];
-    return data.downloads.filter(
+    if (!availableDownloads.length) return [];
+    return availableDownloads.filter(
       (d) =>
         d.file_type === 'gff' &&
         includes(['mobilome_annotation_pipeline'], d.download_group)
     );
-  }, [data]);
+  }, [availableDownloads]);
 
   if (loading || !accession) return <Loading size="small" />;
   if (error) return <p>Error loading analysis</p>;
@@ -165,38 +157,7 @@ const ContigsViewer: React.FC = () => {
                 fastaDownload={fasta}
                 assemblyAccession={accession}
               />
-              {additionalGffs.length > 0 && (
-                <div
-                  className="vf-box vf-box-theme--primary vf-box--easy"
-                  style={{
-                    backgroundColor: '#d1e3f6',
-                  }}
-                >
-                  <div className="vf-flag vf-flag--top vf-flag--reversed vf-flag--800">
-                    <div className="vf-flag__body">
-                      <p className="vf-text-body vf-text-body--3">
-                        Additional GFFs shown are not searchable, but can be
-                        downloaded
-                        <ul className="vf-list vf-list--bare">
-                          {additionalGffs.map((d) => (
-                            <li key={d.alias}>
-                              <p className="vf-text-body vf-text-body--4">
-                                {d.short_description}:{' '}
-                                <a
-                                  href={d.url}
-                                  className="vf-link vf-link--primary vf-link--underline"
-                                >
-                                  {d.alias}
-                                </a>
-                              </p>
-                            </li>
-                          ))}
-                        </ul>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
+              <AdditionalGffNotice additionalGffs={additionalGffs} />
             </LGVProvider>
           }
         />

--- a/src/components/Analysis/Pathways/KeggModule/index.tsx
+++ b/src/components/Analysis/Pathways/KeggModule/index.tsx
@@ -9,12 +9,23 @@ import LegacyFunctionalTable from 'components/Analysis/Functional/LegacyFunction
 type KeggModuleProps = {
   isLegacy?: boolean;
   legacyFile?: Download;
+  dataFiles?: Download[];
+  barChartColumnIndexes?: {
+    label: number;
+    count: number;
+  };
 };
 
-const KeggModuleTab: React.FC<KeggModuleProps> = ({ isLegacy, legacyFile }) => {
+const KeggModuleTab: React.FC<KeggModuleProps> = ({
+  isLegacy,
+  legacyFile,
+  dataFiles: providedDataFiles,
+  barChartColumnIndexes = { label: 1, count: 2 },
+}) => {
   const { overviewData: analysisOverviewData } = useContext(AnalysisContext);
 
   let dataFiles: Download[] | undefined =
+    providedDataFiles ??
     analysisOverviewData?.downloads.filter(
       (file: Download) =>
         file.download_group === 'pathways_and_systems.kegg_modules' &&
@@ -61,7 +72,7 @@ const KeggModuleTab: React.FC<KeggModuleProps> = ({ isLegacy, legacyFile }) => {
     );
   }
 
-  if (!dataFiles) {
+  if (!dataFiles?.length) {
     return (
       <div className="vf-stack vf-stack--200" data-cy="assembly-tsv-table">
         <p>No KEGG modules available</p>
@@ -94,12 +105,12 @@ const KeggModuleTab: React.FC<KeggModuleProps> = ({ isLegacy, legacyFile }) => {
                 labelsCol: {
                   id: 'module_accession',
                   Header: 'Module identifier',
-                  accessor: (d) => d[1],
+                  accessor: (d) => d[barChartColumnIndexes.label],
                 },
                 countsCol: {
                   id: 'completeness',
                   Header: 'Completeness',
-                  accessor: (d) => Number(d[2]),
+                  accessor: (d) => Number(d[barChartColumnIndexes.count]),
                 },
               }}
             />

--- a/src/components/ContigViewer/AdditionalGffNotice.tsx
+++ b/src/components/ContigViewer/AdditionalGffNotice.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Download } from '@/interfaces';
+
+const AdditionalGffNotice: React.FC<{ additionalGffs: Download[] }> = ({
+  additionalGffs,
+}) => {
+  if (additionalGffs.length === 0) return null;
+
+  return (
+    <div
+      className="vf-box vf-box-theme--primary vf-box--easy"
+      style={{
+        backgroundColor: '#d1e3f6',
+      }}
+    >
+      <div className="vf-flag vf-flag--top vf-flag--reversed vf-flag--800">
+        <div className="vf-flag__body">
+          <p className="vf-text-body vf-text-body--3">
+            Additional GFFs shown are not searchable, but can be downloaded
+          </p>
+          <ul className="vf-list vf-list--bare">
+            {additionalGffs.map((d) => (
+              <li key={d.alias || d.url}>
+                <p className="vf-text-body vf-text-body--4">
+                  {d.short_description}:{' '}
+                  <a
+                    href={d.url}
+                    className="vf-link vf-link--primary vf-link--underline"
+                  >
+                    {d.alias || d.url}
+                  </a>
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdditionalGffNotice;

--- a/src/components/ContigViewer/ContigBrowser.tsx
+++ b/src/components/ContigViewer/ContigBrowser.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { JBrowseLinearGenomeView } from '@jbrowse/react-linear-genome-view2';
+import Loading from 'components/UI/Loading';
+import { useLGV } from 'components/Analysis/ContigViewer/V2ContigViewContext';
+
+const ContigBrowser: React.FC = () => {
+  const { viewState } = useLGV();
+  if (!viewState) return <Loading size="small" />;
+  return (
+    <div className="vf-stack vf-stack--400">
+      <JBrowseLinearGenomeView viewState={viewState} />
+    </div>
+  );
+};
+
+export default ContigBrowser;

--- a/src/components/Genomes/ContigViewer/index.tsx
+++ b/src/components/Genomes/ContigViewer/index.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo } from 'react';
+import { find } from 'lodash-es';
+
+import { Download } from '@/interfaces';
+import ContigBrowser from 'components/ContigViewer/ContigBrowser';
+import AdditionalGffNotice from 'components/ContigViewer/AdditionalGffNotice';
+import ContigSearch, {
+  ContigSearchFilterConfig,
+} from 'components/Analysis/ContigViewer/ContigSearch';
+import { LGVProvider } from 'components/Analysis/ContigViewer/V2ContigViewContext';
+import Loading from 'components/UI/Loading';
+
+const genomeFilterConfig: ContigSearchFilterConfig[] = [
+  {
+    title: 'Gene Ontology term',
+    attribute: 'gos',
+    placeholder: 'GO:0003674',
+    gffKey: 'Ontology_term',
+    featureDisplay: 'go',
+  },
+  {
+    title: 'COG Category',
+    attribute: 'cogs',
+    placeholder: 'S',
+    gffKey: 'cog',
+    featureDisplay: 'cog',
+  },
+  {
+    title: 'dbCAN Protein Type',
+    attribute: 'dbcanProtTypes',
+    placeholder: 'CAZyme',
+    gffKey: 'dbcan_prot_type',
+    featureDisplay: 'dbcan',
+  },
+  {
+    title: 'DefenseFinder Activity',
+    attribute: 'defenseFinderActivities',
+    placeholder: 'restriction',
+    gffKey: 'defense_finder_activity',
+    featureDisplay: 'defense',
+  },
+  {
+    title: 'Gene',
+    attribute: 'genes',
+    placeholder: 'tolB',
+    gffKey: 'gene',
+    featureDisplay: 'gene',
+  },
+  {
+    title: 'InterPro',
+    attribute: 'interpros',
+    placeholder: 'IPR003593',
+    gffKey: 'interpro',
+    featureDisplay: 'interpro',
+  },
+  {
+    title: 'KEGG Ortholog',
+    attribute: 'keggs',
+    placeholder: 'ko:K03088',
+    gffKey: 'kegg',
+    featureDisplay: 'kegg',
+  },
+  {
+    title: 'Mobile Element Type',
+    attribute: 'mobileElementTypes',
+    placeholder: 'plasmid',
+    gffKey: 'mobile_element_type',
+    featureDisplay: 'mobile',
+  },
+  {
+    title: 'Pfam',
+    attribute: 'pfams',
+    placeholder: 'PF00005',
+    gffKey: 'pfam',
+    featureDisplay: 'pfam',
+  },
+  {
+    title: 'Rfam',
+    attribute: 'rfams',
+    placeholder: 'RF00005',
+    gffKey: 'rfam',
+    featureDisplay: 'rfam',
+  },
+  {
+    title: 'dbCAN PUL Substrate',
+    attribute: 'dbcanPulSubstrates',
+    placeholder: 'capsule polysaccharide synthesis',
+    gffKey: 'substrate_dbcan-pul',
+    featureDisplay: 'dbcan-pul',
+  },
+  {
+    title: 'dbCAN Substrate',
+    attribute: 'dbcanSubstrates',
+    placeholder: 'starch',
+    gffKey: 'substrate_dbcan-sub',
+    featureDisplay: 'dbcan-sub',
+  },
+  {
+    title: 'ViPhOG Taxonomy',
+    attribute: 'viphogTaxonomies',
+    placeholder: 'Caudoviricetes',
+    gffKey: 'viphog_taxonomy',
+    featureDisplay: 'viphog',
+  },
+  {
+    title: 'AMR Drug Class',
+    attribute: 'amrDrugClasses',
+    placeholder: 'BETA-LACTAM',
+    gffKey: 'drug_class',
+    featureDisplay: 'amr-drug',
+  },
+  {
+    title: 'AMR Drug Subclass',
+    attribute: 'amrDrugSubclasses',
+    placeholder: 'CARBAPENEM',
+    gffKey: 'drug_subclass',
+    featureDisplay: 'amr-subdrug',
+  },
+  {
+    title: 'AMR Element Type',
+    attribute: 'amrElementTypes',
+    placeholder: 'AMR',
+    gffKey: 'element_type',
+    featureDisplay: 'amr-element',
+  },
+  {
+    title: 'AMR Element Subtype',
+    attribute: 'amrElementSubtypes',
+    placeholder: 'AMR',
+    gffKey: 'element_subtype',
+    featureDisplay: 'amr-subelement',
+  },
+  {
+    title: 'MiBIG Class',
+    attribute: 'mibigClasses',
+    placeholder: 'Saccharide',
+    gffKey: 'nearest_MiBIG_class',
+    featureDisplay: 'mibig',
+  },
+  {
+    title: 'antiSMASH Product',
+    attribute: 'antismashProducts',
+    placeholder: 'terpene',
+    gffKey: 'antismash_product',
+    featureDisplay: 'antismash',
+  },
+  {
+    title: 'antiSMASH Function',
+    attribute: 'antismashFunctions',
+    placeholder: 'biosynthetic',
+    gffKey: 'antismash_bgc_function',
+    featureDisplay: 'antismash-function',
+  },
+  {
+    title: 'GECCO BGC Type',
+    attribute: 'geccoBgcTypes',
+    placeholder: 'Terpene',
+    gffKey: 'gecco_bgc_type',
+    featureDisplay: 'gecco',
+  },
+];
+
+type GenomeContigViewerProps = {
+  accession: string;
+  downloads: Download[];
+};
+
+const downloadName = (download: Download) =>
+  download.alias || download.url.split('/').pop() || '';
+
+const isGenomeFna = (download: Download) => {
+  const name = downloadName(download).toLowerCase();
+  return (
+    name.endsWith('.fna') ||
+    name.endsWith('.fa') ||
+    name.endsWith('.fasta') ||
+    download.long_description?.toLowerCase() === 'nucleic acid sequence' ||
+    download.short_description?.toLowerCase() === 'nucleic acid sequence'
+  );
+};
+
+const isGff = (download: Download) =>
+  download.file_type === 'gff' ||
+  downloadName(download).toLowerCase().endsWith('.gff');
+
+const findGenomeFasta = (downloads: Download[]) =>
+  find(downloads, isGenomeFna) ??
+  find(downloads, (d) => d.file_type === 'fna') ??
+  find(
+    downloads,
+    (d) => d.file_type === 'fasta' && !downloadName(d).endsWith('.faa')
+  );
+
+const findGenomeGff = (downloads: Download[], accession: string) =>
+  find(
+    downloads,
+    (d) =>
+      isGff(d) &&
+      (d.alias === `${accession}.gff` ||
+        d.url.endsWith(`/${accession}.gff`) ||
+        (!d.alias?.includes('_virify') && !d.alias?.includes('_sanntis')))
+  ) ?? find(downloads, isGff);
+
+const withDownloadAlias = (
+  download: Download | undefined
+): Download | undefined => {
+  if (!download || download.alias) return download;
+  return {
+    ...download,
+    alias: download.url.split('/').pop() || download.file_type,
+  };
+};
+
+const GenomeContigViewer: React.FC<GenomeContigViewerProps> = ({
+  accession,
+  downloads,
+}) => {
+  const fasta = useMemo(
+    () => withDownloadAlias(findGenomeFasta(downloads)),
+    [downloads]
+  );
+
+  const gff = useMemo(
+    () => withDownloadAlias(findGenomeGff(downloads, accession)),
+    [downloads, accession]
+  );
+
+  const additionalGffs = useMemo(() => {
+    if (!downloads.length) return [];
+    return downloads.filter((d) => isGff(d) && d !== gff);
+  }, [downloads, gff]);
+
+  if (!accession) return <Loading size="small" />;
+  if (!fasta) return <p>No contigs fasta file available</p>;
+  if (!gff) return <p>No annotations available</p>;
+
+  return (
+    <LGVProvider fasta={fasta} gff={gff} additionalGffs={additionalGffs}>
+      <div className="vf-stack vf-stack--400">
+        <ContigBrowser />
+        <ContigSearch
+          gffDownload={gff}
+          fastaDownload={fasta}
+          assemblyAccession={accession}
+          entityLabel="genome"
+          filterConfig={genomeFilterConfig}
+          hideUnavailableFilters
+        />
+        <AdditionalGffNotice additionalGffs={additionalGffs} />
+      </div>
+    </LGVProvider>
+  );
+};
+
+export default GenomeContigViewer;

--- a/src/components/Genomes/KeggPathwayAnalysis/index.tsx
+++ b/src/components/Genomes/KeggPathwayAnalysis/index.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react';
+import { Download } from '@/interfaces';
+import KeggModule from 'components/Analysis/Pathways/KeggModule';
+
+type GenomeKeggPathwayAnalysisProps = {
+  downloads: Download[];
+};
+
+const isKeggPathwayCompleteness = (download: Download) => {
+  const searchable = [
+    download.alias,
+    download.short_description,
+    download.long_description,
+    download.url,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    download.file_type === 'tsv' &&
+    searchable.includes('kegg') &&
+    searchable.includes('pathway') &&
+    (searchable.includes('completeness') ||
+      searchable.includes('_kegg_pathways.tsv'))
+  );
+};
+
+const GenomeKeggPathwayAnalysis: React.FC<GenomeKeggPathwayAnalysisProps> = ({
+  downloads,
+}) => {
+  const keggPathwayDownloads = useMemo(
+    () => downloads.filter(isKeggPathwayCompleteness),
+    [downloads]
+  );
+
+  return (
+    <KeggModule
+      dataFiles={keggPathwayDownloads}
+      barChartColumnIndexes={{ label: 0, count: 1 }}
+    />
+  );
+};
+
+export default GenomeKeggPathwayAnalysis;

--- a/src/components/UI/CompressedTSVTable/IndexedBGZipTSVTable.tsx
+++ b/src/components/UI/CompressedTSVTable/IndexedBGZipTSVTable.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import type { PaginatedList } from '@/interfaces';
+import { BGZipService } from 'components/Analysis/BgZipService';
+import TSVTableView from './TSVTableView';
+import type { TSVTableLoaderProps } from './types';
+
+const DEFAULT_PAGE_SIZE = 100;
+const EMPTY_PAGE: PaginatedList<string[]> = { items: [], count: 0 };
+
+const normalizePageNumber = (pageNum: number): number =>
+  Math.max(1, Number(pageNum) || 1);
+
+const IndexedBGZipTSVTable: React.FC<TSVTableLoaderProps> = ({
+  barChartSpec,
+  columnHeaders,
+  columns = [],
+  download,
+  pageNum,
+  setPageNum,
+}) => {
+  const [reader] = useState(() => new BGZipService(download, false));
+  const [pageData, setPageData] = useState<PaginatedList<string[]>>(EMPTY_PAGE);
+  const [headerRow, setHeaderRow] = useState<string[]>();
+  const [estimatedPageSize, setEstimatedPageSize] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const estimatedPageSizeRef = useRef(0);
+  const firstPagePromiseRef = useRef<Promise<string[][]>>();
+  const firstRowIsHeader = columns.length === 0;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const initialized = await reader.initialize();
+        if (!initialized || cancelled) return;
+
+        if (!firstPagePromiseRef.current) {
+          const firstPagePromise = reader.readPageAsTSV(1);
+          firstPagePromiseRef.current = firstPagePromise;
+          firstPagePromise.catch(() => {
+            if (firstPagePromiseRef.current === firstPagePromise) {
+              firstPagePromiseRef.current = undefined;
+            }
+          });
+        }
+
+        // Reading page one first lets BGZipService account for a leading
+        // comments-only block before it maps logical page numbers.
+        const firstPageRows = await firstPagePromiseRef.current;
+        if (cancelled) return;
+
+        const totalPages = Math.max(1, reader.getPageCount() || 1);
+        const currentPage = Math.min(normalizePageNumber(pageNum), totalPages);
+        if (currentPage !== pageNum) setPageNum(currentPage);
+
+        const response =
+          currentPage === 1
+            ? firstPageRows
+            : await reader.readPageAsTSV(currentPage);
+        if (cancelled) return;
+
+        const nextEstimatedPageSize = Math.max(
+          estimatedPageSizeRef.current,
+          firstPageRows.length,
+          response.length
+        );
+        estimatedPageSizeRef.current = nextEstimatedPageSize;
+        setEstimatedPageSize(nextEstimatedPageSize);
+
+        const items = [...response];
+        if (firstRowIsHeader) {
+          setHeaderRow(firstPageRows[0]);
+          if (currentPage === 1) items.shift();
+        } else {
+          setHeaderRow(undefined);
+        }
+
+        const estimatedRowCount =
+          totalPages * Math.max(nextEstimatedPageSize, response.length, 1) -
+          (firstRowIsHeader && firstPageRows.length ? 1 : 0);
+        setPageData({
+          items,
+          count: Math.max(0, estimatedRowCount),
+        });
+      } catch {
+        if (!cancelled) setPageData(EMPTY_PAGE);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [firstRowIsHeader, pageNum, reader, setPageNum]);
+
+  return (
+    <TSVTableView
+      barChartSpec={barChartSpec}
+      columnHeaders={columnHeaders}
+      columns={columns}
+      data={pageData}
+      expectedPageSize={
+        estimatedPageSize || pageData.items.length || DEFAULT_PAGE_SIZE
+      }
+      headerRow={headerRow}
+      isLoading={isLoading}
+    />
+  );
+};
+
+export default IndexedBGZipTSVTable;

--- a/src/components/UI/CompressedTSVTable/PlainTSVTable.tsx
+++ b/src/components/UI/CompressedTSVTable/PlainTSVTable.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+import type { PaginatedList } from '@/interfaces';
+import TSVTableView from './TSVTableView';
+import type { TSVTableLoaderProps } from './types';
+
+const PAGE_SIZE = 100;
+
+const parseRows = (text: string, leadingCommentChars = '#'): string[][] =>
+  text
+    .split('\n')
+    .filter(
+      (line) => line.trim().length > 0 && !line.startsWith(leadingCommentChars)
+    )
+    .map((line) => line.split('\t'));
+
+const normalizePageNumber = (pageNum: number): number =>
+  Math.max(1, Number(pageNum) || 1);
+
+type RowsState = {
+  rows: string[][] | null;
+  url: string;
+};
+
+const PlainTSVTable: React.FC<TSVTableLoaderProps> = ({
+  barChartSpec,
+  columnHeaders,
+  columns = [],
+  download,
+  pageNum,
+  setPageNum,
+}) => {
+  const [rowsState, setRowsState] = useState<RowsState>({
+    rows: null,
+    url: download.url,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const url = download.url;
+
+    setRowsState({ rows: null, url });
+    fetch(url)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch TSV file: ${response.status} ${response.statusText}`
+          );
+        }
+        return parseRows(await response.text());
+      })
+      .then((rows) => {
+        if (!cancelled) setRowsState({ rows, url });
+      })
+      .catch(() => {
+        if (!cancelled) setRowsState({ rows: [], url });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [download.url]);
+
+  const rows = rowsState.url === download.url ? rowsState.rows : null;
+  const firstRowIsHeader = columns.length === 0;
+  const headerRow = firstRowIsHeader ? rows?.[0] : undefined;
+  const dataRows = useMemo(
+    () => (firstRowIsHeader ? rows?.slice(1) : rows) ?? [],
+    [firstRowIsHeader, rows]
+  );
+  const totalPages = Math.max(1, Math.ceil(dataRows.length / PAGE_SIZE));
+  const currentPage = Math.min(normalizePageNumber(pageNum), totalPages);
+
+  useEffect(() => {
+    if (rows !== null && currentPage !== pageNum) setPageNum(currentPage);
+  }, [currentPage, pageNum, rows, setPageNum]);
+
+  const pageData = useMemo<PaginatedList<string[]>>(() => {
+    const offset = (currentPage - 1) * PAGE_SIZE;
+    return {
+      items: dataRows.slice(offset, offset + PAGE_SIZE),
+      count: dataRows.length,
+    };
+  }, [currentPage, dataRows]);
+
+  return (
+    <TSVTableView
+      barChartSpec={barChartSpec}
+      columnHeaders={columnHeaders}
+      columns={columns}
+      data={pageData}
+      expectedPageSize={PAGE_SIZE}
+      headerRow={headerRow}
+      isLoading={rows === null}
+    />
+  );
+};
+
+export default PlainTSVTable;

--- a/src/components/UI/CompressedTSVTable/TSVTableView.tsx
+++ b/src/components/UI/CompressedTSVTable/TSVTableView.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState } from 'react';
+import { startCase } from 'lodash-es';
+import type { Column } from 'react-table';
+
+import BarChartForTable from 'components/Analysis/BarChartForTable';
+import EMGTable from 'components/UI/EMGTable';
+import FixedHeightScrollable from 'components/UI/FixedHeightScrollable';
+import Loading from 'components/UI/Loading';
+import type { TSVTableViewProps } from './types';
+
+const columnsFromHeader = (
+  headerRow: string[],
+  columnHeaders?: string[]
+): Column[] =>
+  headerRow.map((header, columnIndex) => ({
+    Header:
+      columnHeaders?.[columnIndex] ??
+      (header.includes('_') ? startCase(header) : header),
+    accessor: (row) => row[columnIndex],
+    id: `col_${columnIndex}`,
+  }));
+
+const TSVTableView: React.FC<TSVTableViewProps> = ({
+  barChartSpec,
+  columnHeaders,
+  columns = [],
+  data,
+  expectedPageSize,
+  headerRow,
+  isLoading,
+}) => {
+  const [viewMode, setViewMode] = useState<'table' | 'chart'>('table');
+  const tableColumns = useMemo(
+    () =>
+      columns.length
+        ? columns
+        : columnsFromHeader(headerRow ?? [], columnHeaders),
+    [columnHeaders, columns, headerRow]
+  );
+
+  return (
+    <div className="compressed-tsv-table">
+      <FixedHeightScrollable heightPx={600}>
+        {barChartSpec && (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              position: 'sticky',
+              top: 0,
+              zIndex: 1,
+              backgroundColor: 'white',
+              padding: '0.5rem 0',
+            }}
+          >
+            <button
+              type="button"
+              className="vf-search__button | vf-button vf-button--primary mg-text-search-button vf-button--sm"
+              onClick={() =>
+                setViewMode((currentMode) =>
+                  currentMode === 'table' ? 'chart' : 'table'
+                )
+              }
+            >
+              <span
+                className={`icon icon-common icon-${
+                  viewMode === 'table' ? 'chart-bar' : 'table'
+                }`}
+                style={{ color: '#dcfce7' }}
+              />
+              <span className="vf-button__text">
+                Switch to {viewMode === 'table' ? 'chart' : 'table'} view
+              </span>
+            </button>
+          </div>
+        )}
+
+        {isLoading && <Loading />}
+        {!isLoading && viewMode === 'table' && (
+          <EMGTable
+            cols={tableColumns}
+            data={data}
+            showPagination
+            expectedPageSize={expectedPageSize}
+          />
+        )}
+        {!isLoading && viewMode === 'chart' && barChartSpec && (
+          <BarChartForTable data={data} {...barChartSpec} />
+        )}
+      </FixedHeightScrollable>
+    </div>
+  );
+};
+
+export default TSVTableView;

--- a/src/components/UI/CompressedTSVTable/index.tsx
+++ b/src/components/UI/CompressedTSVTable/index.tsx
@@ -1,182 +1,30 @@
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
-import { Download, PaginatedList } from '@/interfaces';
-import './style.css';
+import React from 'react';
+
 import { BGZipService } from 'components/Analysis/BgZipService';
-import Loading from 'components/UI/Loading';
-import EMGTable from 'components/UI/EMGTable';
-import { Column } from 'react-table';
 import { createSharedQueryParamContextForTable } from 'hooks/queryParamState/useQueryParamState';
-import { startCase } from 'lodash-es';
-import FixedHeightScrollable from 'components/UI/FixedHeightScrollable';
-import BarChartForTable, {
-  BarChartForTableProps,
-} from 'components/Analysis/BarChartForTable';
-
-type BarChartSpec = Pick<
-  BarChartForTableProps,
-  'title' | 'labelsCol' | 'countsCol' | 'maxLabels'
->;
-
-interface CompressedTSVTableProps {
-  columns?: Column[];
-  columnHeaders?: string[];
-  download: Download;
-  barChartSpec?: BarChartSpec;
-}
+import IndexedBGZipTSVTable from './IndexedBGZipTSVTable';
+import PlainTSVTable from './PlainTSVTable';
+import type { TSVTableProps } from './types';
+import './style.css';
 
 const { usePage, withQueryParamProvider } =
   createSharedQueryParamContextForTable();
 
 /**
- * A component for displaying and interacting with compressed TSV files
+ * Displays an ordinary TSV file or an indexed BGZF-compressed TSV file.
+ * Can also take a plain TSV file as input, for cases where the BGZF-compression is not done.
  */
-const CompressedTSVTable: React.FC<CompressedTSVTableProps> = ({
-  columns = [],
-  columnHeaders,
-  download,
-  barChartSpec,
-}) => {
-  const bgzipReader = useMemo(() => new BGZipService(download), [download]);
+const CompressedTSVTable: React.FC<TSVTableProps> = (props) => {
+  const { download } = props;
   const [pageNum, setPageNum] = usePage<number>();
-  const [pageData, setPageData] = useState<PaginatedList>({
-    items: [],
-    count: 0,
-  });
-  const [estimatedPageSize, setEstimatedPageSize] = useState<number>(0);
-  const [cols, setCols] = useState<Column[]>(columns);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const columnsAreFirstRowOfFirstPage = !columns.length;
-  const [viewMode, setViewMode] = useState<'table' | 'chart'>('table');
+  const indexUrl = BGZipService.getIndexFileUrl(download);
+  const sourceKey = JSON.stringify([download.url, indexUrl]);
+  const loaderProps = { ...props, pageNum, setPageNum };
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      setIsLoading(true);
-      try {
-        // Ensure the service is initialized before any page read
-        const ok = await bgzipReader.initialize();
-        if (!ok || cancelled) return;
-
-        // Clamp the current page to the available range (default 1)
-        const totalPages = Math.max(1, bgzipReader.getPageCount?.() || 1);
-        const requestedPage = Math.max(1, Number(pageNum) || 1);
-        const currentPage = Math.min(requestedPage, totalPages);
-        if (currentPage !== pageNum && typeof setPageNum === 'function') {
-          setPageNum(currentPage);
-        }
-
-        const response = await bgzipReader.readPageAsTSV(currentPage);
-        if (cancelled) return;
-
-        if (response.length > estimatedPageSize) {
-          setEstimatedPageSize(response.length);
-        }
-
-        const pageCount = Math.max(1, bgzipReader.getPageCount?.() || 1);
-        let count =
-          pageCount *
-          Math.max(
-            estimatedPageSize || response.length || 1,
-            response.length || 1
-          );
-        const items = [...response];
-
-        if (
-          columnsAreFirstRowOfFirstPage &&
-          currentPage === 1 &&
-          items.length
-        ) {
-          const rowToUseAsHeaders = items[0] as string[];
-          count = Math.max(0, count - 1);
-          items.shift();
-
-          setCols(
-            rowToUseAsHeaders.map((header, colNum) => ({
-              Header:
-                columnHeaders?.[colNum] ??
-                (header.includes('_') ? startCase(header) : header),
-              accessor: (row) => row[colNum],
-              id: `col_${colNum}`,
-            }))
-          );
-        }
-
-        setPageData({ items, count } as PaginatedList);
-      } catch {
-        if (!cancelled) {
-          // Don’t mask with empty data; surface as an empty dataset but stop the spinner
-          setPageData({ items: [], count: 0 });
-        }
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    };
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [pageNum, bgzipReader, estimatedPageSize, columnsAreFirstRowOfFirstPage]);
-
-  const viewModeSelector = barChartSpec ? (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'flex-end',
-        position: 'sticky',
-        top: 0,
-        zIndex: 1,
-        backgroundColor: 'white',
-        padding: '0.5rem 0',
-      }}
-    >
-      <button
-        type="button"
-        className={`vf-search__button | vf-button vf-button--primary mg-text-search-button vf-button--sm`}
-        onClick={() => setViewMode(viewMode === 'table' ? 'chart' : 'table')}
-      >
-        <span
-          className={`icon icon-common icon-${
-            viewMode === 'table' ? 'chart-bar' : 'table'
-          }`}
-          style={{ color: '#dcfce7' }}
-        />
-        <span className="vf-button__text">
-          Switch to {viewMode === 'table' ? 'chart' : 'table'} view
-        </span>
-      </button>
-    </div>
-  ) : null;
-
-  let content: ReactElement | null = null;
-  if (isLoading) content = <Loading />;
-  else if (viewMode === 'table')
-    content = (
-      <EMGTable
-        cols={cols}
-        data={pageData}
-        showPagination
-        expectedPageSize={estimatedPageSize || pageData.items?.length || 100}
-      />
-    );
-  else if (viewMode === 'chart' && barChartSpec)
-    content = (
-      <BarChartForTable
-        data={pageData}
-        labelsCol={barChartSpec?.labelsCol}
-        countsCol={barChartSpec?.countsCol}
-        title={barChartSpec?.title}
-      />
-    );
-
-  return (
-    <div className="compressed-tsv-table">
-      <FixedHeightScrollable heightPx={600}>
-        {viewModeSelector}
-        {content}
-      </FixedHeightScrollable>
-    </div>
+  return indexUrl ? (
+    <IndexedBGZipTSVTable key={sourceKey} {...loaderProps} />
+  ) : (
+    <PlainTSVTable key={sourceKey} {...loaderProps} />
   );
 };
 

--- a/src/components/UI/CompressedTSVTable/types.ts
+++ b/src/components/UI/CompressedTSVTable/types.ts
@@ -1,0 +1,27 @@
+import type { Download, PaginatedList } from '@/interfaces';
+import type { BarChartForTableProps } from 'components/Analysis/BarChartForTable';
+import type { Column } from 'react-table';
+
+export type BarChartSpec = Pick<
+  BarChartForTableProps,
+  'title' | 'labelsCol' | 'countsCol' | 'maxLabels'
+>;
+
+export interface TSVTableProps {
+  columns?: Column[];
+  columnHeaders?: string[];
+  download: Download;
+  barChartSpec?: BarChartSpec;
+}
+
+export interface TSVTableLoaderProps extends TSVTableProps {
+  pageNum: number;
+  setPageNum: (pageNum: number) => void;
+}
+
+export interface TSVTableViewProps extends Omit<TSVTableProps, 'download'> {
+  data: PaginatedList<string[]>;
+  expectedPageSize: number;
+  headerRow?: string[];
+  isLoading: boolean;
+}

--- a/src/components/UI/TextInputTypeahead/index.tsx
+++ b/src/components/UI/TextInputTypeahead/index.tsx
@@ -8,6 +8,7 @@ export const KEYWORD_ANY = 'ANY' as const;
 
 type TextInputTypeaheadProps = {
   namespace: string;
+  searchParamName?: string;
   placeholder?: string;
   title?: string;
   getSuggestions?: (query: string) => Promise<string[]>;
@@ -15,12 +16,13 @@ type TextInputTypeaheadProps = {
 
 const TextInputTypeahead: React.FC<TextInputTypeaheadProps> = ({
   namespace,
+  searchParamName,
   placeholder = 'Enter your search terms',
   title = 'Filter',
   getSuggestions,
 }) => {
   const [searchParam, setSearchParam] = useQueryParamState<string>(
-    camelCase(`${namespace} search`)
+    searchParamName ?? camelCase(`${namespace} search`)
   );
   const [value, setValue] = useState<string>(searchParam || '');
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -46,7 +48,10 @@ const TextInputTypeahead: React.FC<TextInputTypeaheadProps> = ({
   }, [debouncedValue]);
 
   useEffect(() => {
-    if (getSuggestions && value.trim() && value.length >= 2) {
+    if (
+      getSuggestions &&
+      (value.trim().length >= 1 || document.activeElement === inputRef.current)
+    ) {
       getSuggestions(value.trim())
         .then((results) => {
           setSuggestions(results);
@@ -66,6 +71,20 @@ const TextInputTypeahead: React.FC<TextInputTypeaheadProps> = ({
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const v = event.target.value;
     setValue(v);
+  };
+
+  const handleFocus = (): void => {
+    if (!getSuggestions || value.trim()) return;
+    getSuggestions('')
+      .then((results) => {
+        setSuggestions(results);
+        setShowSuggestions(results.length > 0);
+        setActiveSuggestionIndex(-1);
+      })
+      .catch(() => {
+        setSuggestions([]);
+        setShowSuggestions(false);
+      });
   };
 
   const handleSuggestionClick = (suggestion: string): void => {
@@ -130,20 +149,16 @@ const TextInputTypeahead: React.FC<TextInputTypeaheadProps> = ({
 
   return (
     <div className="vf-form__item mg-textsearch mg-typeahead">
-      <label
-        className="vf-form__label vf-search__label"
-        htmlFor={`searchitem-${namespace}`}
-      >
-        {title}
-      </label>
       <div className="mg-typeahead-container">
         <input
           ref={inputRef}
           type="search"
+          aria-label={title}
           placeholder={placeholder}
           id={`searchitem-${namespace}`}
           className="vf-form__input"
           onChange={handleOnChange}
+          onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
           value={value}

--- a/src/hooks/queryParamState/useQueryParamState/index.tsx
+++ b/src/hooks/queryParamState/useQueryParamState/index.tsx
@@ -4,7 +4,7 @@ import SharedQueryParamsProvider, {
   SharedQueryParamSet,
   SharedTextQueryParam,
 } from '@/hooks/queryParamState/QueryParamStore/QueryParamContext';
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { camelCase, forEach, upperFirst } from 'lodash-es';
 
 
@@ -12,15 +12,19 @@ function useSharedQueryParamState<T>(
   parameter: string,
 ): readonly [T, (next: T) => void] {
   const { queryParams, setQueryParams } = useContext(SharedQueryParamContext);
-
-  return [
-    (queryParams[parameter]?.value as unknown as T ) ?? queryParams[parameter]?.defaultValue as T ?? (undefined as unknown as T),
+  const setValue = useCallback(
     (next: T) => {
       setQueryParams((prev: SharedQueryParamSet) => ({
         ...prev,
         [parameter]: { ...(prev?.[parameter] ?? {}), value: next },
       }));
     },
+    [parameter, setQueryParams]
+  );
+
+  return [
+    (queryParams[parameter]?.value as unknown as T ) ?? queryParams[parameter]?.defaultValue as T ?? (undefined as unknown as T),
+    setValue,
   ];
 }
 

--- a/src/interfaces/index.tsx
+++ b/src/interfaces/index.tsx
@@ -26,6 +26,11 @@ export interface Download {
   long_description: string;
   short_description: string;
   url: string;
+  index_file?: {
+    index_type: string;
+    path?: string;
+    url?: string;
+  } | null;
   index_files?: {
     index_type: string;
     url: string;

--- a/src/pages/Genome/index.tsx
+++ b/src/pages/Genome/index.tsx
@@ -35,7 +35,6 @@ import {
   getContainmentHistogram,
   getCountryColor,
   getScatterData,
-  getTotalCountryCount,
 } from 'utils/branchwater';
 import { getPrefixedBranchwaterConfig } from 'components/Branchwater/common/queryParamConfig';
 
@@ -46,17 +45,21 @@ const { withQueryParamProvider } = createSharedQueryParamContextForTable(
   '-containment'
 );
 
-const GenomeBrowser = lazy(() => import('components/Genomes/Browser'));
+const GenomeBrowser = lazy(() => import('components/Genomes/ContigViewer'));
 const GenomeGenericAnalysis = lazy(
   () => import('components/Genomes/Annotations')
+);
+const GenomeKeggPathwayAnalysis = lazy(
+  () => import('components/Genomes/KeggPathwayAnalysis')
 );
 
 const tabs = [
   { label: 'Overview', to: '#overview' },
   { label: 'Browse genome', to: '#genome-browser' },
-  { label: 'COG analysis', to: '#cog-analysis' },
-  { label: 'KEGG class analysis', to: '#kegg-class-analysis' },
-  { label: 'KEGG module analysis', to: '#kegg-module-analysis' },
+  { label: 'COG', to: '#cog-analysis' },
+  { label: 'KEGG classes', to: '#kegg-class-analysis' },
+  { label: 'KEGG modules', to: '#kegg-module-analysis' },
+  { label: 'KEGG pathways', to: '#kegg-pathway-analysis' },
   { label: 'Presence in metagenomes', to: '#metagenome-search' },
   { label: 'Downloads', to: '#downloads' },
 ];
@@ -182,11 +185,6 @@ const GenomePage: React.FC = () => {
     [mapSamples, mapPinsLimit]
   );
 
-  const totalCountryCount = useMemo(
-    () => getTotalCountryCount(countryCounts),
-    [countryCounts]
-  );
-
   const containmentHistogram = useMemo(
     () => getContainmentHistogram(searchResults),
     [searchResults]
@@ -275,7 +273,10 @@ const GenomePage: React.FC = () => {
           </RouteForHash>
           <RouteForHash hash="#genome-browser">
             <Suspense fallback={<Loading size="large" />}>
-              <GenomeBrowser />
+              <GenomeBrowser
+                accession={accession}
+                downloads={data.downloads ?? []}
+              />
             </Suspense>
           </RouteForHash>
           <RouteForHash hash="#cog-analysis">
@@ -324,6 +325,11 @@ const GenomePage: React.FC = () => {
               />
             </Suspense>
           </RouteForHash>
+          <RouteForHash hash="#kegg-pathway-analysis">
+            <Suspense fallback={<Loading size="large" />}>
+              <GenomeKeggPathwayAnalysis downloads={data.downloads ?? []} />
+            </Suspense>
+          </RouteForHash>
           <RouteForHash hash="#metagenome-search">
             <div className="vf-stack vf-stack--400">
               <h3>Branchwater</h3>
@@ -355,7 +361,9 @@ const GenomePage: React.FC = () => {
                     isTableVisible={isTableVisible}
                     setIsTableVisible={setIsTableVisible}
                     filters={filters}
-                    onFilterChange={onFilterChange}
+                    onFilterChange={(field, value) =>
+                      onFilterChange(field as keyof BranchwaterFilters, value)
+                    }
                     sortField={order.replace(/^-/, '')}
                     sortDirection={order.startsWith('-') ? 'desc' : 'asc'}
                     onSortChange={onSortChange}
@@ -368,7 +376,6 @@ const GenomePage: React.FC = () => {
                     mapSamples={mapSamples}
                     displayedMapSamples={displayedMapSamples}
                     setMapPinsLimit={setMapPinsLimit}
-                    totalCountryCount={totalCountryCount}
                     getCountryColor={getCountryColor}
                     downloadCSV={downloadCSV}
                     queryParamPrefix="genomeBranchwaterDetailed"

--- a/src/utils/locallyIndexedGff.ts
+++ b/src/utils/locallyIndexedGff.ts
@@ -2,35 +2,35 @@ import Dexie, { Table } from 'dexie';
 import * as Comlink from 'comlink';
 import { filter, flatMap, forIn, groupBy, map, uniq } from 'lodash-es';
 import { RemoteFile } from 'generic-filehandle2';
-import { BgzipIndexedFasta } from '@gmod/indexedfasta';
+import { BgzipIndexedFasta, IndexedFasta } from '@gmod/indexedfasta';
 
 export type ContigDetails = {
   contigName: string;
   length: number;
-  annotations: {
-    interpros?: string[];
-    pfams?: string[];
-    cogs?: string[];
-    keggs?: string[];
-    gos?: string[];
-  };
-  annotationsPresence: {
-    hasInterpros?: number;
-    hasPfams?: number;
-    hasCogs?: number;
-    hasKeggs?: number;
-    hasGos?: number;
-  };
+  annotationText: string;
+  annotations: Record<string, string[] | undefined>;
+  annotationsPresence: Record<string, number | undefined>;
 };
 
 export type Contig = ContigDetails & {
   contigId: number;
 };
 
-type MetaKeys = 'assemblyAccession' | 'importStartedAt' | 'sourceUrl';
+type MetaKeys =
+  | 'assemblyAccession'
+  | 'importStartedAt'
+  | 'sourceUrl'
+  | 'indexSpec';
 
 export function contigNameToContigId(contigName: string): number {
-  return parseInt(contigName.split('_')[1]);
+  const numericSuffix = parseInt(contigName.split('_')[1], 10);
+  if (Number.isFinite(numericSuffix)) return numericSuffix;
+
+  let hash = 0;
+  for (let i = 0; i < contigName.length; i++) {
+    hash = (hash * 31 + contigName.charCodeAt(i)) % Number.MAX_SAFE_INTEGER;
+  }
+  return hash;
 }
 
 class GffDB extends Dexie {
@@ -38,11 +38,32 @@ class GffDB extends Dexie {
   meta!: Table<{ key: MetaKeys; value: any }, string>;
   constructor(name = 'gffdb') {
     super(name);
-    this.version(2).stores({
+    this.version(5).stores({
       contigs:
         'contigId, length, *annotations.interpros, *annotations.pfams, *annotations.cogs, *annotations.keggs, *annotations.gos, ' +
+        '*annotations.eggnogs, *annotations.ecNumbers, *annotations.genes, *annotations.products, *annotations.rfams, ' +
+        '*annotations.mibigs, *annotations.mibigClasses, *annotations.dbXrefs, ' +
+        '*annotations.geccoBgcTypes, *annotations.antismashProducts, *annotations.antismashFunctions, ' +
+        '*annotations.dbcanProtTypes, *annotations.dbcanProtFamilies, *annotations.dbcanPulSubstrates, ' +
+        '*annotations.dbcanSubstrates, *annotations.amrGenes, *annotations.amrDrugClasses, *annotations.amrDrugSubclasses, ' +
+        '*annotations.amrElementTypes, *annotations.amrElementSubtypes, *annotations.mobileElementTypes, *annotations.mobileOGs, ' +
+        '*annotations.trnaIsotypes, *annotations.ncrnaClasses, *annotations.defenseFinderTypes, ' +
+        '*annotations.defenseFinderSubtypes, *annotations.defenseFinderActivities, *annotations.viralTaxonomies, ' +
+        '*annotations.viphogTaxonomies, ' +
         'annotationsPresence.hasInterpros, annotationsPresence.hasPfams, annotationsPresence.hasCogs, ' +
-        'annotationsPresence.hasKeggs, annotationsPresence.hasGos',
+        'annotationsPresence.hasKeggs, annotationsPresence.hasGos, annotationsPresence.hasEggnogs, ' +
+        'annotationsPresence.hasEcNumbers, annotationsPresence.hasGenes, annotationsPresence.hasProducts, ' +
+        'annotationsPresence.hasRfams, annotationsPresence.hasMibigs, annotationsPresence.hasMibigClasses, ' +
+        'annotationsPresence.hasDbXrefs, annotationsPresence.hasGeccoBgcTypes, annotationsPresence.hasAntismashProducts, ' +
+        'annotationsPresence.hasAntismashFunctions, annotationsPresence.hasDbcanProtTypes, annotationsPresence.hasDbcanProtFamilies, ' +
+        'annotationsPresence.hasDbcanPulSubstrates, annotationsPresence.hasDbcanSubstrates, annotationsPresence.hasAmrGenes, ' +
+        'annotationsPresence.hasAmrDrugClasses, annotationsPresence.hasAmrDrugSubclasses, annotationsPresence.hasAmrElementTypes, ' +
+        'annotationsPresence.hasAmrElementSubtypes, annotationsPresence.hasMobileElementTypes, ' +
+        'annotationsPresence.hasMobileOGs, annotationsPresence.hasTrnaIsotypes, ' +
+        'annotationsPresence.hasNcrnaClasses, annotationsPresence.hasDefenseFinderTypes, ' +
+        'annotationsPresence.hasDefenseFinderSubtypes, annotationsPresence.hasDefenseFinderActivities, ' +
+        'annotationsPresence.hasViralTaxonomies, ' +
+        'annotationsPresence.hasViphogTaxonomies',
       //contigId is the primary key since named first - this is the contig integer index so that contigs
       // can be sorted by contig index rather than alphanumerically... contig 312 should be after contig 99.
       // The assembly key needs prepended to this to make a locus tag.
@@ -65,7 +86,7 @@ type WorkerApi = {
    */
   importGff: (
     url: string,
-    indexUrl: string,
+    indexUrl: string | undefined,
     onProgress: (bytes: number, total?: number) => void,
     onBatch: (rows: any[]) => Promise<void>,
     attrsToIndex: string[],
@@ -85,11 +106,11 @@ function createWorker() {
 export type ImportOptions = {
   url: string; // to get annots
   assemblyAccession: string;
-  indexUrl: string; // to paginate gff
+  indexUrl?: string; // to paginate bgzipped gff when available
   fastaUrl?: string; // to get the length of each contig
   fastaFaiUrl?: string; // ^
   fastaGziUrl?: string; // ^
-  attrsToIndex: string[]; // e.g. ['interpro', 'pfam', ...]
+  attrsToIndex: Array<TypeAheadAttributes | GffAttributeIndexSpec>;
   batchSize?: number; // gff lines per indexing batch,
   // may be useful for performance tuning otherwise remove and rely on blockzip size as batch
   onProgress?: (info: {
@@ -108,21 +129,134 @@ export type TypeAheadAttributes =
   | 'pfams'
   | 'keggs'
   | 'gos'
-  | 'cogs';
+  | 'cogs'
+  | 'eggnogs'
+  | 'ecNumbers'
+  | 'genes'
+  | 'products'
+  | 'rfams'
+  | 'mibigs'
+  | 'mibigClasses'
+  | 'dbXrefs'
+  | 'geccoBgcTypes'
+  | 'antismashProducts'
+  | 'antismashFunctions'
+  | 'dbcanProtTypes'
+  | 'dbcanProtFamilies'
+  | 'dbcanPulSubstrates'
+  | 'dbcanSubstrates'
+  | 'amrGenes'
+  | 'amrDrugClasses'
+  | 'amrDrugSubclasses'
+  | 'amrElementTypes'
+  | 'amrElementSubtypes'
+  | 'mobileElementTypes'
+  | 'mobileOGs'
+  | 'trnaIsotypes'
+  | 'ncrnaClasses'
+  | 'defenseFinderTypes'
+  | 'defenseFinderSubtypes'
+  | 'defenseFinderActivities'
+  | 'viralTaxonomies'
+  | 'viphogTaxonomies';
+
+export type GffAttributeIndexSpec = {
+  gffKey: string | string[];
+  field: TypeAheadAttributes;
+};
+
+export const PRESENCE_FIELD_BY_ATTRIBUTE: Record<TypeAheadAttributes, string> =
+  {
+    interpros: 'hasInterpros',
+    pfams: 'hasPfams',
+    cogs: 'hasCogs',
+    keggs: 'hasKeggs',
+    gos: 'hasGos',
+    eggnogs: 'hasEggnogs',
+    ecNumbers: 'hasEcNumbers',
+    genes: 'hasGenes',
+    products: 'hasProducts',
+    rfams: 'hasRfams',
+    mibigs: 'hasMibigs',
+    mibigClasses: 'hasMibigClasses',
+    dbXrefs: 'hasDbXrefs',
+    geccoBgcTypes: 'hasGeccoBgcTypes',
+    antismashProducts: 'hasAntismashProducts',
+    antismashFunctions: 'hasAntismashFunctions',
+    dbcanProtTypes: 'hasDbcanProtTypes',
+    dbcanProtFamilies: 'hasDbcanProtFamilies',
+    dbcanPulSubstrates: 'hasDbcanPulSubstrates',
+    dbcanSubstrates: 'hasDbcanSubstrates',
+    amrGenes: 'hasAmrGenes',
+    amrDrugClasses: 'hasAmrDrugClasses',
+    amrDrugSubclasses: 'hasAmrDrugSubclasses',
+    amrElementTypes: 'hasAmrElementTypes',
+    amrElementSubtypes: 'hasAmrElementSubtypes',
+    mobileElementTypes: 'hasMobileElementTypes',
+    mobileOGs: 'hasMobileOGs',
+    trnaIsotypes: 'hasTrnaIsotypes',
+    ncrnaClasses: 'hasNcrnaClasses',
+    defenseFinderTypes: 'hasDefenseFinderTypes',
+    defenseFinderSubtypes: 'hasDefenseFinderSubtypes',
+    defenseFinderActivities: 'hasDefenseFinderActivities',
+    viralTaxonomies: 'hasViralTaxonomies',
+    viphogTaxonomies: 'hasViphogTaxonomies',
+  };
+
+const normalizeAttributeIndexSpecs = (
+  attrsToIndex: Array<TypeAheadAttributes | GffAttributeIndexSpec>
+): GffAttributeIndexSpec[] =>
+  attrsToIndex.map((attr) =>
+    typeof attr === 'string' ? { gffKey: attr, field: attr } : attr
+  );
+
+const GFF_INDEX_CONTENT_VERSION = 2;
+
+export const getGffIndexSpec = (
+  attrsToIndex: Array<TypeAheadAttributes | GffAttributeIndexSpec>
+): string =>
+  JSON.stringify({
+    contentVersion: GFF_INDEX_CONTENT_VERSION,
+    attributes: normalizeAttributeIndexSpecs(attrsToIndex),
+  });
+
+const getPresenceFlags = (
+  annotations: ContigDetails['annotations']
+): ContigDetails['annotationsPresence'] =>
+  Object.fromEntries(
+    Object.entries(PRESENCE_FIELD_BY_ATTRIBUTE).map(([attribute, presence]) => [
+      presence,
+      (annotations[attribute]?.length ?? 0) > 0 ? 1 : 0,
+    ])
+  );
 
 export async function getTypeaheadSuggestions(
   query: string,
   attribute: TypeAheadAttributes,
   limit: number = 10
 ): Promise<string[]> {
-  if (!query || query.length < 1) return [];
-
   try {
     const upperQuery = query.toUpperCase();
+    const indexName = `annotations.${attribute}`;
+
+    if (!query) {
+      const contigs = await db.contigs
+        .orderBy(indexName)
+        .limit(limit * 5)
+        .toArray();
+
+      return Array.from(
+        new Set(
+          contigs.flatMap((contig) => contig.annotations[attribute] || [])
+        )
+      )
+        .sort()
+        .slice(0, limit);
+    }
 
     // Get all unique attributes (e.g. interpros) that start with the query
     const suggestions = await db.contigs
-      .where(`annotations.${attribute}`)
+      .where(indexName)
       .startsWithIgnoreCase(upperQuery)
       .limit(limit * 3) // Get more than needed to account for duplicates. *3 is a guess.
       .toArray();
@@ -143,7 +277,7 @@ export function importGffToIndexedDB(opts: ImportOptions) {
   const {
     url,
     assemblyAccession,
-    indexUrl,
+    indexUrl = undefined,
     fastaUrl = undefined,
     fastaFaiUrl = undefined,
     fastaGziUrl = undefined,
@@ -155,6 +289,7 @@ export function importGffToIndexedDB(opts: ImportOptions) {
     onError,
     clearExisting = true,
   } = opts;
+  const attrIndexSpecs = normalizeAttributeIndexSpecs(attrsToIndex);
   // Ask for persistent storage (helps avoid eviction on large datasets)
   // Fire and forget; ignore if unsupported
   navigator.storage?.persist?.();
@@ -175,6 +310,7 @@ export function importGffToIndexedDB(opts: ImportOptions) {
     contigId: Contig['contigId'];
     contigName: Contig['contigName'];
     length?: Contig['length'];
+    annotationTextToAppend: Contig['annotationText'];
     annotsToAppend: Contig['annotations'];
   };
 
@@ -182,15 +318,23 @@ export function importGffToIndexedDB(opts: ImportOptions) {
     updates: contigUpsertDefinition[]
   ) {
     const merged = new Map<Contig['contigId'], ContigDetails>();
-    for (const { contigId, annotsToAppend, contigName, length } of updates) {
+    for (const {
+      contigId,
+      annotsToAppend,
+      annotationTextToAppend,
+      contigName,
+      length,
+    } of updates) {
       const acc =
         merged.get(contigId) ??
         ({
           contigName: contigName,
           length: length,
+          annotationText: '',
           annotations: {},
           annotationsPresence: {},
         } as ContigDetails);
+      acc.annotationText += annotationTextToAppend;
       for (const [annotType, annotValues] of Object.entries(annotsToAppend)) {
         if (!Array.isArray(annotValues)) continue;
         const prev = (acc as any).annotations[annotType] as any[] | undefined;
@@ -217,6 +361,8 @@ export function importGffToIndexedDB(opts: ImportOptions) {
           // Update: append + dedupe each annotation within nested annotations.*
           const next: Contig = {
             ...row,
+            annotationText:
+              (row.annotationText || '') + appendObj.annotationText,
             annotations: { ...(row.annotations || {}) },
           };
           for (const [field, vals] of Object.entries(appendObj.annotations)) {
@@ -228,37 +374,23 @@ export function importGffToIndexedDB(opts: ImportOptions) {
               ...(vals as any[]),
             ]);
           }
-          // compute presence flags (length > 0)
-          (next as any).annotationsPresence = {
-            hasInterpros: (next.annotations.interpros?.length ?? 0) > 0 ? 1 : 0,
-            hasPfams: (next.annotations.pfams?.length ?? 0) > 0 ? 1 : 0,
-            hasCogs: (next.annotations.cogs?.length ?? 0) > 0 ? 1 : 0,
-            hasKeggs: (next.annotations.keggs?.length ?? 0) > 0 ? 1 : 0,
-            hasGos: (next.annotations.gos?.length ?? 0) > 0 ? 1 : 0,
-          };
+          next.annotationsPresence = getPresenceFlags(next.annotations);
 
           toUpdate.push(next);
         } else {
-          const ann = {
-            interpros: uniq((appendObj.annotations.interpros ?? []) as any[]),
-            pfams: uniq((appendObj.annotations.pfams ?? []) as any[]),
-            cogs: uniq(appendObj.annotations.cogs ?? []),
-            keggs: uniq(appendObj.annotations.keggs ?? []),
-            gos: uniq((appendObj.annotations.gos ?? []) as any[]),
-          };
+          const ann = Object.fromEntries(
+            attrIndexSpecs.map(({ field }) => [
+              field,
+              uniq((appendObj.annotations[field] ?? []) as string[]),
+            ])
+          ) as ContigDetails['annotations'];
           const draft: any = {
             contigId: id,
             contigName: appendObj.contigName,
             length: appendObj.length,
+            annotationText: appendObj.annotationText,
             annotations: ann,
-            // compute presence flags (length > 0)
-            annotationsPresence: {
-              hasInterpros: ann.interpros.length > 0 ? 1 : 0,
-              hasPfams: ann.pfams.length > 0 ? 1 : 0,
-              hasCogs: ann.cogs.length > 0 ? 1 : 0,
-              hasKeggs: ann.keggs.length > 0 ? 1 : 0,
-              hasGos: ann.gos.length > 0 ? 1 : 0,
-            },
+            annotationsPresence: getPresenceFlags(ann),
           };
           toAdd.push(draft as Contig);
         }
@@ -272,39 +404,33 @@ export function importGffToIndexedDB(opts: ImportOptions) {
   const onBatch = Comlink.proxy(async (rows: any[]) => {
     if (!rows?.length || cancelled) return;
 
-    let contigsToUpsert: contigUpsertDefinition[] = [];
+    const contigsToUpsert: contigUpsertDefinition[] = [];
 
     forIn(
       groupBy(rows, (row) => row.seqid),
       (annotations, contigId) => {
-        contigsToUpsert.push({
-          contigId: contigNameToContigId(contigId),
-          contigName: contigId,
-          annotsToAppend: {
-            interpros: filter(
-              flatMap(annotations, (row) => row.indexableAttrValues.interpro),
-              (annot) => !!annot
-            ),
-            pfams: filter(
-              flatMap(annotations, (row) => row.indexableAttrValues.pfam),
-              (annot) => !!annot
-            ),
-            cogs: filter(
-              flatMap(annotations, (row) => row.indexableAttrValues.cog),
-              (annot) => !!annot
-            ),
-            keggs: filter(
-              flatMap(annotations, (row) => row.indexableAttrValues.kegg),
-              (annot) => !!annot
-            ),
-            gos: filter(
-              flatMap(
-                annotations,
-                (row) => row.indexableAttrValues.Ontology_term
+        const annotsToAppend = Object.fromEntries(
+          attrIndexSpecs.map(({ gffKey, field }) => [
+            field,
+            filter(
+              flatMap(Array.isArray(gffKey) ? gffKey : [gffKey], (key) =>
+                flatMap(
+                  annotations,
+                  (row) => row.indexableAttrValues[key.toLowerCase()]
+                )
               ),
               (annot) => !!annot
             ),
-          },
+          ])
+        ) as Contig['annotations'];
+
+        contigsToUpsert.push({
+          contigId: contigNameToContigId(contigId),
+          contigName: contigId,
+          annotationTextToAppend: annotations
+            .map((row) => row.annotationText || '')
+            .join(''),
+          annotsToAppend,
         });
       }
     );
@@ -320,6 +446,10 @@ export function importGffToIndexedDB(opts: ImportOptions) {
           await db.contigs.clear();
           await db.meta.put({ key: 'sourceUrl', value: url });
           await db.meta.put({
+            key: 'indexSpec',
+            value: getGffIndexSpec(attrIndexSpecs),
+          });
+          await db.meta.put({
             key: 'assemblyAccession',
             value: assemblyAccession,
           });
@@ -332,19 +462,30 @@ export function importGffToIndexedDB(opts: ImportOptions) {
         indexUrl,
         Comlink.proxy(progressCb),
         Comlink.proxy(onBatch),
-        attrsToIndex,
+        Array.from(
+          new Set(
+            flatMap(attrIndexSpecs, ({ gffKey }) =>
+              Array.isArray(gffKey) ? gffKey : [gffKey]
+            )
+          )
+        ),
         batchSize
       );
 
       const seconds = (performance.now() - startT) / 1000;
 
-      if (fastaUrl && fastaFaiUrl && fastaGziUrl) {
-        const fastaBgzHandler = new BgzipIndexedFasta({
-          fasta: new RemoteFile(fastaUrl),
-          fai: new RemoteFile(fastaFaiUrl),
-          gzi: new RemoteFile(fastaGziUrl),
-        });
-        const contigLengths = await fastaBgzHandler.getSequenceSizes();
+      if (fastaUrl && fastaFaiUrl) {
+        const fastaHandler = fastaGziUrl
+          ? new BgzipIndexedFasta({
+              fasta: new RemoteFile(fastaUrl),
+              fai: new RemoteFile(fastaFaiUrl),
+              gzi: new RemoteFile(fastaGziUrl),
+            })
+          : new IndexedFasta({
+              fasta: new RemoteFile(fastaUrl),
+              fai: new RemoteFile(fastaFaiUrl),
+            });
+        const contigLengths = await fastaHandler.getSequenceSizes();
         await db.transaction('rw', db.meta, db.contigs, async () => {
           await db.contigs.bulkUpdate(
             map(contigLengths, (length, contigName) => ({

--- a/src/utils/locallyIndexedGff.worker.ts
+++ b/src/utils/locallyIndexedGff.worker.ts
@@ -1,4 +1,4 @@
-// Worker (so background thread) to stream BGZF GFF in browser
+// Worker (so background thread) to stream GFF in browser
 import { expose } from 'comlink';
 import { BgzfFilehandle } from '@gmod/bgzf-filehandle';
 
@@ -109,6 +109,39 @@ function makeLineProcessor(onLine: (line: string) => void) {
   };
 }
 
+function makePlainGffLineProcessor(onLine: (line: string) => void) {
+  let carry = '';
+  let seenFasta = false;
+  return (u8: Uint8Array, finalize = false): boolean => {
+    if (seenFasta) return true;
+    const text = textDecoder.decode(u8, { stream: !finalize });
+    let start = 0;
+    for (let i = 0; i < text.length; i++) {
+      if (text.charCodeAt(i) === 10) {
+        const line = carry + text.slice(start, i).replace(/\r$/, '');
+        carry = '';
+        start = i + 1;
+        if (line === '##FASTA') {
+          seenFasta = true;
+          return true;
+        }
+        if (line && line[0] !== '#') onLine(line);
+      }
+    }
+    carry += text.slice(start);
+    if (finalize && carry) {
+      const line = carry.replace(/\r$/, '');
+      carry = '';
+      if (line === '##FASTA') {
+        seenFasta = true;
+        return true;
+      }
+      if (line && line[0] !== '#') onLine(line);
+    }
+    return seenFasta;
+  };
+}
+
 // Minimal scanner for GFF attributes that only extracts requested keys.
 function parseSelectedAttributes(
   attrs: string | undefined,
@@ -149,6 +182,7 @@ function parseSelectedAttributes(
     )
       i++;
     const key = attrs.slice(kStart, i).trim();
+    const lookupKey = key.toLowerCase();
     if (i >= len || attrs.charCodeAt(i) !== 61 /* '=' */) {
       // no '='; skip to next ';'
       while (i < len && attrs.charCodeAt(i) !== 59 /* ';' */) i++;
@@ -164,23 +198,23 @@ function parseSelectedAttributes(
     i++; // skip ';' if present
 
     // Only process if key is wanted (either for indexing or known singletons)
-    if (wanted.has(key)) {
+    if (wanted.has(lookupKey)) {
       // Values may be comma-separated for multi-valued attributes
       // Split only when needed (for index targets). For singletons, take first.
-      if (indexTargets.has(key)) {
+      if (indexTargets.has(lookupKey)) {
         // split on commas, conditionally decode
         const vals = rawVal.length
           ? rawVal.split(',').map((s) => conditionalDecode(s))
           : [];
-        if (vals.length) out.indexableAttrValues[key] = vals;
+        if (vals.length) out.indexableAttrValues[lookupKey] = vals;
       } else {
         // singleton: take first value (before comma)
         const first = rawVal.length ? rawVal.split(',', 1)[0] : '';
         const val = conditionalDecode(first);
-        if (key === 'ID') out.idAttr = val;
-        else if (key === 'Parent') out.parent = val;
-        else if (key === 'Name') out.name = val;
-        else if (key === 'product') out.product = val;
+        if (lookupKey === 'id') out.idAttr = val;
+        else if (lookupKey === 'parent') out.parent = val;
+        else if (lookupKey === 'name') out.name = val;
+        else if (lookupKey === 'product') out.product = val;
       }
     }
   }
@@ -239,7 +273,7 @@ async function getUncompressedSizeFromGzi(
 
 async function importGff(
   url: string,
-  indexUrl: string,
+  indexUrl: string | undefined,
   onProgress: (b: number, t?: number) => void,
   onBatch: (rows: any[]) => Promise<void>,
   attrsToIndex: string[],
@@ -247,14 +281,6 @@ async function importGff(
   headers?: HeadersInitLike
 ) {
   const t0 = performance.now();
-
-  // Build BGZF-aware filehandle using our HTTP-range wrapper
-  const fh = new BgzfFilehandle({
-    filehandle: new HttpRangeFilehandle(url, headers),
-    gziFilehandle: new HttpRangeFilehandle(indexUrl, headers),
-  });
-
-  const uncompressedTotal = await getUncompressedSizeFromGzi(indexUrl, headers);
 
   // Backpressure-aware batching with double-buffer and serialized flush
   let emitBatch: any[] = [];
@@ -269,13 +295,13 @@ async function importGff(
   };
 
   // Prepare attribute selection sets
-  const indexTargets = new Set(attrsToIndex);
+  const indexTargets = new Set(attrsToIndex.map((attr) => attr.toLowerCase()));
   const wanted = new Set<string>([
-    'ID',
-    'Parent',
-    'Name',
+    'id',
+    'parent',
+    'name',
     'product',
-    ...attrsToIndex,
+    ...attrsToIndex.map((attr) => attr.toLowerCase()),
   ]);
 
   const onLine = (line: string) => {
@@ -302,6 +328,8 @@ async function importGff(
       parent,
       name,
       product,
+      annotationText:
+        attrs && attrs !== '.' ? `${attrs.replace(/;+$/, '')};` : '',
     });
 
     if (emitBatch.length >= batchSize) {
@@ -311,22 +339,53 @@ async function importGff(
   };
 
   const processLines = makeLineProcessor(onLine);
+  const processPlainLines = makePlainGffLineProcessor(onLine);
 
-  // Stream until EOF
-  // eslint-disable-next-line no-bitwise
-  const CHUNK = 1 << 20; // 1 MiB (uncompressed)
-  let pos = 0;
-  for (;;) {
-    const chunk = await fh.read(CHUNK, pos); // returns Uint8Array (decompressed bytes)
-    if (!chunk.length) break;
-    onProgress(pos + chunk.length, uncompressedTotal);
-    processLines(chunk);
-    // apply backpressure at chunk boundaries
-    await inFlight;
-    pos += chunk.length;
+  if (indexUrl) {
+    // Build BGZF-aware filehandle using our HTTP-range wrapper
+    const fh = new BgzfFilehandle({
+      filehandle: new HttpRangeFilehandle(url, headers),
+      gziFilehandle: new HttpRangeFilehandle(indexUrl, headers),
+    });
+
+    const uncompressedTotal = await getUncompressedSizeFromGzi(
+      indexUrl,
+      headers
+    );
+
+    // Stream until EOF
+    // eslint-disable-next-line no-bitwise
+    const CHUNK = 1 << 20; // 1 MiB (uncompressed)
+    let pos = 0;
+    for (;;) {
+      const chunk = await fh.read(CHUNK, pos); // returns Uint8Array (decompressed bytes)
+      if (!chunk.length) break;
+      onProgress(pos + chunk.length, uncompressedTotal);
+      processLines(chunk);
+      // apply backpressure at chunk boundaries
+      await inFlight;
+      pos += chunk.length;
+    }
+    // finalize any trailing line
+    processLines(new Uint8Array(0), true);
+  } else {
+    const statHandle = new HttpRangeFilehandle(url, headers);
+    const { size } = await statHandle.stat();
+    // eslint-disable-next-line no-bitwise
+    const CHUNK = 1 << 20; // 1 MiB raw HTTP range chunks
+    let pos = 0;
+    for (;;) {
+      const chunk = await statHandle.read(CHUNK, pos);
+      if (!chunk.length) break;
+      onProgress(pos + chunk.length, size);
+      const reachedFasta = processPlainLines(chunk);
+      await inFlight;
+      pos += chunk.length;
+      if (reachedFasta || chunk.length < CHUNK) break;
+    }
+    processPlainLines(new Uint8Array(0), true);
   }
-  // finalize any trailing line
-  processLines(new Uint8Array(0), true);
+
   // flush the remainder and wait for all deliveries
   scheduleFlush();
   await inFlight;


### PR DESCRIPTION
This PR:
- Switches genome browser to JBrowse with local contig indexing (like ASAv6)
- Also adds MGYG Kegg pathways view (also following ASAv6)
  - this meant adding support for non-compressed TSVs to the table/chart viewer we use there, since MGYG kegg module TSVs are plain. This introduced an unfortunately large diff – the plan in future is for the genomes pipeline to output similarly compressed-indexed files as ASAV6 at which point this can be simplified back down.
- Also adds more extensive locally-indexed contig search functon like a free-text search of all column 9 keys/values. 
  - This is because there are too many possible col9 fields to sensibly index & understand as a user through facets, or to know the possible values of, so the free text helps with this.
  - The handling for this is also a bit fiddly to make a searchable string without creating bloat in the in-browser db.

---

Main visual changes:

<img width="1325" height="1271" alt="image" src="https://github.com/user-attachments/assets/b18e4375-fc9d-490e-ad91-285e82acffe4" />
